### PR TITLE
Allow doc comment to set help text

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,23 +11,36 @@ extern crate structopt_derive;
 
 use structopt::StructOpt;
 
+/// A basic example
 #[derive(StructOpt, Debug)]
-#[structopt(name = "basic", about = "A basic example")]
+#[structopt(name = "basic")]
 struct Opt {
-    #[structopt(short = "d", long = "debug", help = "Activate debug mode")]
+    /// Activate debug mode
+    #[structopt(short = "d", long = "debug")]
     debug: bool,
-    #[structopt(short = "v", long = "verbose", help = "Verbose mode")]
+
+    /// Verbose mode
+    #[structopt(short = "v", long = "verbose")]
     verbose: u64,
-    #[structopt(short = "s", long = "speed", help = "Set speed", default_value = "42")]
+
+    /// Set speed
+    #[structopt(short = "s", long = "speed", default_value = "42")]
     speed: f64,
-    #[structopt(short = "o", long = "output", help = "Output file")]
+
+    /// Output file
+    #[structopt(short = "o", long = "output")]
     output: String,
-    #[structopt(short = "c", long = "car", help = "Number of car")]
+
+    /// Number of car
+    #[structopt(short = "c", long = "car")]
     car: Option<i32>,
+
+    /// admin_level to consider
     #[structopt(short = "l", long = "level")]
-    #[structopt(help = "admin_level to consider")]
     level: Vec<String>,
-    #[structopt(name = "FILE", help = "Files to process")]
+
+    /// Files to process
+    #[structopt(name = "FILE")]
     files: Vec<String>,
 }
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -172,7 +172,7 @@ fn extract_attrs<'a>(attrs: &'a [Attribute], attr_source: AttrSource) -> Box<Ite
     Box::new(doc_comments.chain(settings_attrs))
 }
 
-fn from_attr_or_env<'a>(attrs: &[(Ident, Lit)], key: &str, env: &str) -> Lit {
+fn from_attr_or_env(attrs: &[(Ident, Lit)], key: &str, env: &str) -> Lit {
     let default = std::env::var(env).unwrap_or("".into());
     attrs.iter()
         .filter(|&&(ref i, _)| i.as_ref() == key)

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -169,20 +169,22 @@ fn extract_attrs<'a>(attrs: &'a [Attribute], attr_source: AttrSource) -> Box<Ite
             }
         });
 
-    Box::new(settings_attrs.chain(doc_comments))
+    Box::new(doc_comments.chain(settings_attrs))
 }
 
 fn from_attr_or_env<'a>(attrs: &[(Ident, Lit)], key: &str, env: &str) -> Lit {
     let default = std::env::var(env).unwrap_or("".into());
     attrs.iter()
-        .find(|&&(ref i, _)| i.as_ref() == key)
+        .filter(|&&(ref i, _)| i.as_ref() == key)
+        .last()
         .map(|&(_, ref l)| l.clone())
         .unwrap_or_else(|| Lit::Str(default, StrStyle::Cooked))
 }
 
 fn gen_name(field: &Field) -> Ident {
     extract_attrs(&field.attrs, AttrSource::Field)
-        .find(|&(ref i, _)| i.as_ref() == "name")
+        .filter(|&(ref i, _)| i.as_ref() == "name")
+        .last()
         .and_then(|(_, ref l)| match l {
             &Lit::Str(ref s, _) => Some(Ident::new(s.clone())),
             _ => None,

--- a/tests/doc-comments-help.rs
+++ b/tests/doc-comments-help.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 structopt Developers
+//
+// This work is free. You can redistribute it and/or modify it under
+// the terms of the Do What The Fuck You Want To Public License,
+// Version 2, as published by Sam Hocevar. See the COPYING file for
+// more details.
+
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
+
+use structopt::StructOpt;
+
+#[test]
+fn commets_intead_of_actual_help() {
+    /// Lorem ipsum
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct LoremIpsum {
+        /// Fooify a bar
+        #[structopt(short = "f", long = "foo")]
+        foo: bool,
+    }
+
+    let mut output = Vec::new();
+    LoremIpsum::clap().write_long_help(&mut output).unwrap();
+    let output = String::from_utf8(output).unwrap();
+
+    assert!(output.contains("Lorem ipsum"));
+    assert!(output.contains("Fooify a bar"));
+}
+
+#[test]
+fn help_is_better_than_comments() {
+    /// Lorem ipsum
+    #[derive(StructOpt, PartialEq, Debug)]
+    #[structopt(name = "lorem-ipsum", about = "Dolor sit amet")]
+    struct LoremIpsum {
+        /// Fooify a bar
+        #[structopt(short = "f", long = "foo", help = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
+        foo: bool,
+    }
+
+    let mut output = Vec::new();
+    LoremIpsum::clap().write_long_help(&mut output).unwrap();
+    let output = String::from_utf8(output).unwrap();
+
+    println!("{}", output);
+    assert!(output.contains("Dolor sit amet"));
+    assert!(!output.contains("Lorem ipsum"));
+    assert!(output.contains("DO NOT PASS A BAR"));
+}


### PR DESCRIPTION
This treats doc comments as `help`/`about` attributes, which may lead to concatenating the original help text with the doc comment.

I didn't add any tests except for changing the 'basic' example and checking the CLI output myself. If there is anything you want me to add in that regard, let me know :)

fix #13 