### PR TITLE
Add support for subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structopt"
-version = "0.0.6"
+version = "0.1.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parse command line argument by defining a struct."
 documentation = "https://docs.rs/structopt"
@@ -17,6 +17,6 @@ travis-ci = { repository = "TeXitoi/structopt" }
 clap = "2.20"
 
 [dev-dependencies]
-structopt-derive = { path = "structopt-derive", version = "0.0.5" }
+structopt-derive = { path = "structopt-derive", version = "0.1.0" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structopt"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parse command line argument by defining a struct."
 documentation = "https://docs.rs/structopt"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Find it on Docs.rs: [structopt-derive](https://docs.rs/structopt-derive) and [st
 Add `structopt` and `structopt-derive` to your dependencies of your `Cargo.toml`:
 ```toml
 [dependencies]
-structopt = "0.0.6"
-structopt-derive = "0.0.6"
+structopt = "0.1.0"
+structopt-derive = "0.1.0"
 ```
 
 And then, in your rust file:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Find it on Docs.rs: [structopt-derive](https://docs.rs/structopt-derive) and [st
 
 ## Example
 
-Add `structopt` and `structop-derive` to your dependencies of your `Cargo.toml`:
+Add `structopt` and `structopt-derive` to your dependencies of your `Cargo.toml`:
 ```toml
 [dependencies]
-structopt = "0.0.3"
-structopt-derive = "0.0.3"
+structopt = "0.0.6"
+structopt-derive = "0.0.6"
 ```
 
 And then, in your rust file:

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -1,0 +1,40 @@
+//! `git.rs` serves as a demonstration of how to use subcommands,
+//! as well as a demonstration of adding documentation to subcommands.
+//! Documentation can be added either through doc comments or the
+//! `about` attribute.
+
+extern crate structopt;
+#[macro_use] extern crate structopt_derive;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "git")]
+/// the stupid content tracker
+enum Opt {
+    #[structopt(name = "fetch")]
+    /// fetch branches from remote repository
+    Fetch {
+        #[structopt(long = "dry-run")]
+        dry_run: bool,
+        #[structopt(long = "all")]
+        all: bool,
+        #[structopt(default_value = "origin")]
+        repository: String
+    },
+    #[structopt(name = "add")]
+    /// add files to the staging area
+    Add {
+        #[structopt(short = "i")]
+        interactive: bool,
+        #[structopt(short = "a")]
+        all: bool,
+        files: Vec<String>
+    }
+}
+
+fn main() {
+    let matches = Opt::from_args();
+
+    println!("{:?}", matches);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,6 @@ pub trait StructOpt {
     /// Returns the corresponding `clap::App`.
     fn clap<'a, 'b>() -> clap::App<'a, 'b>;
 
-    /// Add this app's arguments/subcommands to another `clap::App`.
-    fn augment_clap<'a, 'b>(clap::App<'a, 'b>) -> clap::App<'a, 'b>;
-
     /// Creates the struct from `clap::ArgMatches`.
     fn from_clap(clap::ArgMatches) -> Self;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@
 //! `StructOpt` trait definition
 //!
 //! This crate defines the `StructOpt` trait.  Alone, this crate is of
-//! little interest.  See the `structopt-derive` crate to
-//! automatically generate implementation of this trait.
+//! little interest.  See the 
+//! [`structopt-derive`](https://docs.rs/structopt-derive) crate to
+//! automatically generate an implementation of this trait.
 
 extern crate clap as _clap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub trait StructOpt {
     /// Returns the corresponding `clap::App`.
     fn clap<'a, 'b>() -> clap::App<'a, 'b>;
 
+    /// Add this app's arguments/subcommands to another `clap::App`.
+    fn augment_clap<'a, 'b>(clap::App<'a, 'b>) -> clap::App<'a, 'b>;
+
     /// Creates the struct from `clap::ArgMatches`.
     fn from_clap(clap::ArgMatches) -> Self;
 

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structopt-derive"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parse command line argument by defining a struct, derive crate."
 documentation = "https://docs.rs/structopt-derive"

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structopt-derive"
-version = "0.0.6"
+version = "0.1.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parse command line argument by defining a struct, derive crate."
 documentation = "https://docs.rs/structopt-derive"

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -5,9 +5,9 @@
 // Version 2, as published by Sam Hocevar. See the COPYING file for
 // more details.
 
-//! How to `derive(StructOpt)`
+//! ## How to `derive(StructOpt)`
 //!
-//! First, look at an example:
+//! First, let's look at an example:
 //!
 //! ```ignore
 //! #[derive(StructOpt)]
@@ -24,28 +24,30 @@
 //! }
 //! ```
 //!
-//! So, `derive(StructOpt)` do the job, and `structopt` attribute is
+//! So `derive(StructOpt)` tells Rust to generate a command line parser, 
+//! and the various `structopt` attributes are simply
 //! used for additional parameters.
 //!
 //! First, define a struct, whatever its name.  This structure will
 //! correspond to a `clap::App`.  Every method of `clap::App` in the
-//! form of `fn function_name(self, &str)` can be use in the form of
-//! attributes.  Our example call for example something like
-//! `app.about("An example of StructOpt usage.")`.  There is some
-//! special attributes:
+//! form of `fn function_name(self, &str)` can be use through attributes
+//! placed on the struct. In our example above, the `about` attribute
+//! will become an `.about("An example of StructOpt usage.")` call on the
+//! generated `clap::App`. There are a few attributes that will default
+//! if not specified:
 //!
-//!   - `name`: correspond to the creation of the `App` object. Our
-//!     example does `clap::App::new("example")`.  Default to
-//!     the crate name given by cargo.
-//!   - `version`: default to the crate version given by cargo.
-//!   - `author`: default to the crate version given by cargo.
-//!   - `about`: default to the crate version given by cargo.
+//!   - `name`: The binary name displayed in help messages. Defaults
+        to the crate name given by Cargo.
+//!   - `version`: Defaults to the crate version given by Cargo.
+//!   - `author`: Defaults to the crate author name given by Cargo.
+//!   - `about`: Defaults to the crate description given by Cargo.
 //!
-//! Then, each field of the struct correspond to a `clap::Arg`.  As
-//! for the struct attributes, every method of `clap::Arg` in the form
-//! of `fn function_name(self, &str)` can be use in the form of
-//! attributes.  The `name` attribute can be used to customize the
-//! `Arg::with_name()` call (default to the field name).
+//! Then, each field of the struct not marked as a subcommand corresponds
+//! to a `clap::Arg`. As with the struct attributes, every method of
+//! `clap::Arg`in the form of `fn function_name(self, &str)` can be used
+//! through specifying it as an attribute.
+//! The `name` attribute can be used to customize the
+//! `Arg::with_name()` call (defaults to the field name).
 //!
 //! The type of the field gives the kind of argument:
 //!
@@ -55,10 +57,10 @@
 //! `u64`                | number of params  | `.takes_value(false).multiple(true)`
 //! `Option<T: FromStr>` | optional argument | `.takes_value(true).multiple(false)`
 //! `Vec<T: FromStr>`    | list of arguments | `.takes_value(true).multiple(true)`
-//! `T: FromStr` | required argument | `.takes_value(true).multiple(false).required(!has_default)`
+//! `T: FromStr`         | required argument | `.takes_value(true).multiple(false).required(!has_default)`
 //!
 //! The `FromStr` trait is used to convert the argument to the given
-//! type, and the `Arg::validator` method is setted to a method using
+//! type, and the `Arg::validator` method is set to a method using
 //! `FromStr::Error::description()`.
 //!
 //! Thus, the `speed` argument is generated as:

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -447,7 +447,13 @@ fn gen_from_subcommand(name: &Ident, variants: &[Variant]) -> quote::Tokens {
 }
 
 fn impl_structopt_for_struct(name: &Ident, fields: &[Field], attrs: &[Attribute]) -> quote::Tokens {
-    let subcmd_required = fields.iter().any(is_subcommand);
+    let subcmd_required = fields.iter().any(|field| {
+        let cur_type = ty(&field.ty);
+        match cur_type {
+            Ty::Option => false,
+            _ => is_subcommand(field)
+        }
+    });
     let clap = gen_clap(attrs, subcmd_required);
     let augment_clap = gen_augment_clap(fields);
     let from_clap = gen_from_clap(name, fields);

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -615,8 +615,11 @@ fn impl_structopt_for_struct(name: &Ident, fields: &[Field], attrs: &[Attribute]
     quote! {
         impl _structopt::StructOpt for #name {
             #clap
-            #augment_clap
             #from_clap
+        }
+
+        impl #name {
+            #augment_clap
         }
     }
 }
@@ -637,11 +640,11 @@ fn impl_structopt_for_enum(name: &Ident, variants: &[Variant], attrs: &[Attribut
     quote! {
         impl _structopt::StructOpt for #name {
             #clap
-            #augment_clap
             #from_clap
         }
 
         impl #name {
+            #augment_clap
             #from_subcommand
         }
     }

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -181,6 +181,25 @@
 //! + `make-cookie pound 50`
 //! + `make-cookie sparkle -mmm --color "green"`
 //! + `make-cookie finish 130 glaze 3`
+//!
+//! ### Optional subcommands
+//!
+//! A nested subcommand can be marked optional:
+//!
+//! #[derive(StructOpt)]
+//! #[structopt(name = "foo")]
+//! struct Foo {
+//!     file: String,
+//!     #[structopt(subcommand)]
+//!     cmd: Option<Command>
+//! }
+//! 
+//! #[derive(StructOpt)]
+//! enum Command {
+//!     Bar {},
+//!     Baz {},
+//!     Quux {}
+//! }
 
 extern crate proc_macro;
 extern crate syn;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -499,7 +499,8 @@ fn impl_structopt(ast: &DeriveInput) -> quote::Tokens {
 
     let dummy_const = Ident::new(format!("_IMPL_STRUCTOPT_FOR_{}", struct_name));
     quote! {
-        #[allow(non_upper_case_globals, unused_attributes, unused_imports)]
+        #[allow(non_upper_case_globals)]
+        #[allow(unused_attributes, unused_imports, unused_variables)]
         const #dummy_const: () = {
             extern crate structopt as _structopt;
             use structopt::StructOpt;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! Then, each field of the struct not marked as a subcommand corresponds
 //! to a `clap::Arg`. As with the struct attributes, every method of
-//! `clap::Arg`in the form of `fn function_name(self, &str)` can be used
+//! `clap::Arg` in the form of `fn function_name(self, &str)` can be used
 //! through specifying it as an attribute.
 //! The `name` attribute can be used to customize the
 //! `Arg::with_name()` call (defaults to the field name).
@@ -97,7 +97,7 @@
 //! }
 //! ```
 //!
-//! ## Subcomamnds
+//! ## Subcommands
 //! 
 //! Some applications, like `git`, support "subcommands;" an extra command that
 //! is used to differentiate what the application should do. With `git`, these

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -146,7 +146,7 @@
 //! #[derive(StructOpt)]
 //! #[structopt(name = "make-cookie")]
 //! struct MakeCookie {
-//!     #[structopt(name = "supervisor", default_value = "Puck")]
+//!     #[structopt(name = "supervisor", default_value = "Puck", required = false, long = "supervisor")]
 //!     supervising_faerie: String,
 //!     #[structopt(name = "tree")]
 //!     /// The faerie tree this cookie is being made in.

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -147,7 +147,7 @@
 //! #[structopt(name = "make-cookie")]
 //! struct MakeCookie {
 //!     #[structopt(name = "supervisor", default_value = "Puck")]
-//!     supervising_faerie: Option<String>,
+//!     supervising_faerie: String,
 //!     #[structopt(name = "tree")]
 //!     /// The faerie tree this cookie is being made in.
 //!     tree: Option<String>,

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -379,11 +379,11 @@ fn gen_augment_clap_enum(variants: &[Variant]) -> quote::Tokens {
         let name = extract_attrs(&variant.attrs, AttrSource::Struct)
             .filter_map(|attr| match attr {
                 (ref i, Lit::Str(ref s, ..)) if i == "name" => 
-                    Some(Ident::new(s as &str)),
+                    Some(s.to_string()),
                 _ => None
             })
             .next()
-            .unwrap_or_else(|| variant.ident.clone());
+            .unwrap_or_else(|| variant.ident.to_string());
         let app_var = Ident::new("subcommand");
         let arg_block = match variant.data {
             VariantData::Struct(ref fields) => gen_augmentation(fields, &app_var),
@@ -392,7 +392,7 @@ fn gen_augment_clap_enum(variants: &[Variant]) -> quote::Tokens {
 
         quote! {
             .subcommand({
-                let #app_var = _structopt::clap::SubCommand::with_name( stringify!(#name) );
+                let #app_var = _structopt::clap::SubCommand::with_name( #name );
                 #arg_block
             })
         }

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -206,6 +206,7 @@
 //!
 //! A nested subcommand can be marked optional:
 //!
+//! ```ignore
 //! #[derive(StructOpt)]
 //! #[structopt(name = "foo")]
 //! struct Foo {
@@ -220,6 +221,7 @@
 //!     Baz {},
 //!     Quux {}
 //! }
+//! ```
 
 extern crate proc_macro;
 extern crate syn;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -535,6 +535,7 @@ fn gen_augment_clap_enum(variants: &[Variant]) -> quote::Tokens {
         let app_var = Ident::new("subcommand");
         let arg_block = match variant.data {
             VariantData::Struct(ref fields) => gen_augmentation(fields, &app_var),
+            VariantData::Unit => quote!( #app_var ),
             _ => unreachable!()
         };
         let from_attr = extract_attrs(&variant.attrs, AttrSource::Struct)
@@ -579,6 +580,7 @@ fn gen_from_subcommand(name: &Ident, variants: &[Variant]) -> quote::Tokens {
         let variant_name = &variant.ident;
         let constructor_block = match variant.data {
             VariantData::Struct(ref fields) => gen_constructor(fields),
+            VariantData::Unit => quote!(),  // empty
             _ => unreachable!()
         };
         
@@ -621,10 +623,10 @@ fn impl_structopt_for_struct(name: &Ident, fields: &[Field], attrs: &[Attribute]
 
 fn impl_structopt_for_enum(name: &Ident, variants: &[Variant], attrs: &[Attribute]) -> quote::Tokens {
     if variants.iter().any(|variant| {
-            if let VariantData::Struct(..) = variant.data { false } else { true }
+            if let VariantData::Tuple(..) = variant.data { true } else { false }
         })
     {
-        panic!("enum variants must use curly braces");
+        panic!("enum variants cannot be tuples");
     }
 
     let clap = gen_clap_enum(attrs);

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -217,9 +217,9 @@
 //! 
 //! #[derive(StructOpt)]
 //! enum Command {
-//!     Bar {},
-//!     Baz {},
-//!     Quux {}
+//!     Bar,
+//!     Baz,
+//!     Quux
 //! }
 //! ```
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -76,6 +76,111 @@
 //!     .help("Set speed")
 //!     .default_value("42")
 //! ```
+//!
+//! ## Subcomamnds
+//! 
+//! Some applications, like `git`, support "subcommands;" an extra command that
+//! is used to differentiate what the application should do. With `git`, these
+//! would be `add`, `init`, `fetch`, `commit`, for a few examples.
+//!
+//! `clap` has this functionality, so `structopt` supports this through enums:
+//!
+//! ```ignore
+//! #[derive(StructOpt)]
+//! #[structopt(name = "git", about = "the stupid content tracker")]
+//! enum Git {
+//!     #[structopt(name = "add")]
+//!     Add {
+//!         #[structopt(short = "i")]
+//!         interactive: bool,
+//!         #[structopt(short = "p")]
+//!         patch: bool,
+//!         files: Vec<String>
+//!     },
+//!     #[structopt(name = "fetch")]
+//!     Fetch {
+//!         #[structopt(long = "dry-run")]
+//!         dry_run: bool,
+//!         #[structopt(long = "all")]
+//!         all: bool,
+//!         repository: Option<String>
+//!     },
+//!     #[structopt(name = "commit")]
+//!     Commit {
+//!         #[structopt(short = "m")]
+//!         message: Option<String>,
+//!         #[structopt(short = "a")]
+//!         all: bool
+//!     }
+//! }
+//! ```
+//!
+//! Using `derive(StructOpt)` on an enum instead of a struct will produce
+//! a `clap::App` that only takes subcommands. So `git add`, `git fetch`,
+//! and `git commit` would be commands allowed for the above example.
+//!
+//! `structopt` also provides support for applications where certain flags
+//! need to apply to all subcommands, as well as nested subcommands:
+//!
+//! ```ignore
+//! #[derive(StructOpt)]
+//! #[structopt(name = "make-cookie")]
+//! struct MakeCookie {
+//!     #[structopt(name = "supervisor", default_value = "Puck")]
+//!     supervising_faerie: Option<String>,
+//!     #[structopt(name = "tree")]
+//!     /// The faerie tree this cookie is being made in.
+//!     tree: Option<String>,
+//!     #[structopt(subcommand)]  // Note that we mark a field as a subcommand
+//!     cmd: Command
+//! }
+//! 
+//! #[derive(StructOpt)]
+//! enum Command {
+//!     #[structopt(name = "pound")]
+//!     /// Pound acorns into flour for cookie dough.
+//!     Pound {
+//!         acorns: u32
+//!     },
+//!     #[structopt(name = "sparkle")]
+//!     /// Add magical sparkles -- the secret ingredient!
+//!     Sparkle {
+//!         #[structopt(short = "m")]
+//!         magicality: u64,
+//!         #[structopt(short = "c")]
+//!         color: String
+//!     },
+//!     #[structopt(name = "finish")]
+//!     Finish {
+//!         #[structopt(short = "t")]
+//!         time: u32,
+//!         #[structopt(subcommand)]  // Note that we mark a field as a subcommand
+//!         type: FinishType
+//!     }
+//! }
+//! 
+//! #[derive(StructOpt)]
+//! enum FinishType {
+//!     #[structopt(name = "glaze")]
+//!     Glaze {
+//!         applications: u32
+//!     },
+//!     #[structopt(name = "powder")]
+//!     Powder {
+//!         flavor: String,
+//!         dips: u32
+//!     }
+//! }
+//! ```
+//!
+//! Marking a field with `structopt(subcommand)` will add the subcommands of the
+//! designated enum to the current `clap::App`. The designated enum *must* also
+//! be derived `StructOpt`. So the above example would take the following
+//! commands:
+//! 
+//! + `make-cookie pound 50`
+//! + `make-cookie sparkle -mmm --color "green"`
+//! + `make-cookie finish 130 glaze 3`
 
 extern crate proc_macro;
 extern crate syn;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -37,7 +37,7 @@
 //! if not specified:
 //!
 //!   - `name`: The binary name displayed in help messages. Defaults
-        to the crate name given by Cargo.
+//!      to the crate name given by Cargo.
 //!   - `version`: Defaults to the crate version given by Cargo.
 //!   - `author`: Defaults to the crate author name given by Cargo.
 //!   - `about`: Defaults to the crate description given by Cargo.
@@ -75,6 +75,26 @@
 //!     .long("debug")
 //!     .help("Set speed")
 //!     .default_value("42")
+//! ```
+//!
+//! ## Help messages
+//!
+//! Help messages for the whole binary or individual arguments can be
+//! specified using the `about` attribute on the struct/field, as we've
+//! already seen. For convenience, they can also be specified using
+//! doc comments. For example:
+//!
+//! ```ignore
+//! #[derive(StructOpt)]
+//! #[structopt(name = "foo")]
+//! /// The help message that will be displayed when passing `--help`.
+//! struct Foo {
+//!   ...
+//!   #[structopt(short = "b")]
+//!   /// The description for the arg that will be displayed when passing `--help`.
+//!   bar: String
+//!   ...
+//! }
 //! ```
 //!
 //! ## Subcomamnds

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -399,7 +399,7 @@ fn gen_from_subcommand(name: &Ident, variants: &[Variant]) -> quote::Tokens {
     });
 
     quote! {
-        fn from_subcommand<'a, 'b>(sub: (&'b str, Option<&'b _structopt::clap::ArgMatches<'a, 'b>>)) -> Option<Self> {
+        fn from_subcommand<'a, 'b>(sub: (&'b str, Option<&'b _structopt::clap::ArgMatches<'a>>)) -> Option<Self> {
             match sub {
                 #( #match_arms ),*,
                 _ => None

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -359,6 +359,9 @@ fn gen_augmentation(fields: &[Field], app_var: &Ident) -> quote::Tokens {
             quote!( let #app_var = #subcmd_type ::augment_clap( #app_var ); )
         })
         .collect();
+
+    assert!(subcmds.len() <= 1, "cannot have more than one nested subcommand");
+
     let args = fields.iter()
         .filter(|&field| !is_subcommand(field))
         .map(|field| {
@@ -390,8 +393,6 @@ fn gen_augmentation(fields: &[Field], app_var: &Ident) -> quote::Tokens {
                 .map(|(i, l)| quote!(.#i(#l)));
             quote!( .arg(_structopt::clap::Arg::with_name(stringify!(#name)) #modifier #(#from_attr)*) )
         });
-
-    assert!(subcmds.len() <= 1, "cannot have more than one nested subcommand");
 
     quote! {{
         use std::error::Error;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -300,7 +300,15 @@ fn impl_structopt_for_struct(name: &Ident, fields: &[Field], attrs: &[Attribute]
 }
 
 fn impl_structopt_for_enum(_variants: &[Variant]) -> quote::Tokens {
-    quote!()
+    quote! {
+        impl _structopt::StructOpt for #name {
+        }
+
+        impl #name {
+            fn from_subcommand<'a, 'b>(sub: (&'b str, Option<&'b _structopt::clap::ArgMatches<'a, 'b>>)) -> Option<Self> {
+            }
+        }
+    }
 }
 
 fn impl_structopt(ast: &DeriveInput) -> quote::Tokens {

--- a/tests/nested-subcommands.rs
+++ b/tests/nested-subcommands.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2017 Guillaume Pinot <texitoi(a)texitoi.eu>
+//
+// This work is free. You can redistribute it and/or modify it under
+// the terms of the Do What The Fuck You Want To Public License,
+// Version 2, as published by Sam Hocevar. See the COPYING file for
+// more details.
+
+extern crate structopt;
+#[macro_use] extern crate structopt_derive;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt, PartialEq, Debug)]
+struct Opt {
+    #[structopt(short = "f", long = "force")]
+    force: bool,
+    #[structopt(short = "v", long = "verbose")]
+    verbose: u64,
+    #[structopt(subcommand)]
+    cmd: Sub
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Sub {
+    #[structopt(name = "fetch")]
+    Fetch {},
+    #[structopt(name = "add")]
+    Add {}
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+struct Opt2 {
+    #[structopt(short = "f", long = "force")]
+    force: bool,
+    #[structopt(short = "v", long = "verbose")]
+    verbose: u64,
+    #[structopt(subcommand)]
+    cmd: Option<Sub>
+}
+
+#[test]
+fn test_no_cmd() {
+    let result = Opt::clap().get_matches_from_safe(&["test"]);
+    assert!(result.is_err());
+
+    assert_eq!(Opt2 { force: false, verbose: 0, cmd: None },
+               Opt2::from_clap(Opt2::clap().get_matches_from(&["test"])));
+}
+
+#[test]
+fn test_fetch() {
+    assert_eq!(Opt { force: false, verbose: 3, cmd: Sub::Fetch {} },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-vvv", "fetch"])));
+    assert_eq!(Opt { force: true, verbose: 0, cmd: Sub::Fetch {} },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "--force", "fetch"])));
+}
+
+#[test]
+fn test_add() {
+    assert_eq!(Opt { force: false, verbose: 0, cmd: Sub::Add {} },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "add"])));
+    assert_eq!(Opt { force: false, verbose: 2, cmd: Sub::Add {} },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-vv", "add"])));
+}
+
+#[test]
+fn test_badinput() {
+    let result = Opt::clap().get_matches_from_safe(&["test", "badcmd"]);
+    assert!(result.is_err());
+    let result = Opt::clap().get_matches_from_safe(&["test", "add", "--verbose"]);
+    assert!(result.is_err());
+    let result = Opt::clap().get_matches_from_safe(&["test", "--badopt", "add"]);
+    assert!(result.is_err());
+    let result = Opt::clap().get_matches_from_safe(&["test", "add", "--badopt"]);
+    assert!(result.is_err());
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+struct Opt3 {
+    #[structopt(short = "a", long = "all")]
+    all: bool,
+    #[structopt(subcommand)]
+    cmd: Sub2
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Sub2 {
+    #[structopt(name = "foo")]
+    Foo {
+        file: String,
+        #[structopt(subcommand)]
+        cmd: Sub3
+    },
+    #[structopt(name = "bar")]
+    Bar {
+    }
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Sub3 {
+    #[structopt(name = "baz")]
+    Baz {},
+    #[structopt(name = "quux")]
+    Quux {}
+}
+
+#[test]
+fn test_subsubcommand() {
+    assert_eq!(
+        Opt3 {
+            all: true,
+            cmd: Sub2::Foo { file: "lib.rs".to_string(), cmd: Sub3::Quux {} }
+        },
+        Opt3::from_clap(Opt3::clap().get_matches_from(&["test", "--all", "foo", "lib.rs", "quux"]))
+    );
+}

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -71,3 +71,20 @@ fn test_hyphenated_subcommands() {
     assert_eq!(Opt2::DoSomething { arg: "blah".to_string() },
                Opt2::from_clap(Opt2::clap().get_matches_from(&["test", "do-something", "blah"])));
 }
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Opt3 {
+    #[structopt(name = "add")]
+    Add,
+    #[structopt(name = "init")]
+    Init,
+    #[structopt(name = "fetch")]
+    Fetch
+}
+
+#[test]
+fn test_null_commands() {
+    assert_eq!(Opt3::Add, Opt3::from_clap(Opt3::clap().get_matches_from(&["test", "add"])));
+    assert_eq!(Opt3::Init, Opt3::from_clap(Opt3::clap().get_matches_from(&["test", "init"])));
+    assert_eq!(Opt3::Fetch, Opt3::from_clap(Opt3::clap().get_matches_from(&["test", "fetch"])));
+}

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, PartialEq, Debug)]
 enum Opt {
-    #[structopt(name = "fetch")]
+    #[structopt(name = "fetch", about = "Fetch stuff from GitHub.")]
     Fetch {
         #[structopt(long = "all")]
         all: bool,
@@ -54,4 +54,20 @@ fn test_no_parse() {
 
     let result = Opt::clap().get_matches_from_safe(&["test", "add", "--badoption"]);
     assert!(result.is_err());
+}
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Opt2 {
+    #[structopt(name = "do-something")]
+    DoSomething {
+        arg: String
+    }
+}
+
+#[test]
+/// This test is specifically to make sure that hyphenated subcommands get
+/// processed correctly.
+fn test_hyphenated_subcommands() {
+    assert_eq!(Opt2::DoSomething { arg: "blah".to_string() },
+               Opt2::from_clap(Opt2::clap().get_matches_from(&["test", "do-something", "blah"])));
 }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Guillaume Pinot <texitoi(a)texitoi.eu>
+//
+// This work is free. You can redistribute it and/or modify it under
+// the terms of the Do What The Fuck You Want To Public License,
+// Version 2, as published by Sam Hocevar. See the COPYING file for
+// more details.
+
+extern crate structopt;
+#[macro_use] extern crate structopt_derive;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt, PartialEq, Debug)]
+enum Opt {
+    #[structopt(name = "fetch")]
+    Fetch {
+        #[structopt(long = "all")]
+        all: bool,
+        #[structopt(short = "f", long = "force")]
+        /// Overwrite local branches.
+        force: bool,
+        repo: String
+    },
+    
+    #[structopt(name = "add")]
+    Add {
+        #[structopt(short = "i", long = "interactive")]
+        interactive: bool,
+        #[structopt(short = "v", long = "verbose")]
+        verbose: bool
+    }
+}
+
+#[test]
+fn test_fetch() {
+    assert_eq!(Opt::Fetch { all: true, force: false, repo: "origin".to_string() },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "fetch", "--all", "origin"])));
+    assert_eq!(Opt::Fetch { all: false, force: true, repo: "origin".to_string() },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "fetch", "-f", "origin"])));
+}
+
+#[test]
+fn test_add() {
+    assert_eq!(Opt::Add { interactive: false, verbose: false },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "add"])));
+    assert_eq!(Opt::Add { interactive: true, verbose: true },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "add", "-i", "-v"])));
+}
+
+#[test]
+fn test_no_parse() {
+    let result = Opt::clap().get_matches_from_safe(&["test", "badcmd", "-i", "-v"]);
+    assert!(result.is_err());
+
+    let result = Opt::clap().get_matches_from_safe(&["test", "add", "--badoption"]);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
See #1 for detailed discussion of this feature.

Adds the ability to use `#[derive(StructOpt)]` on enums, thereby allowing the creation/easy parsing of `clap::SubCommand`s.

**This is not a breaking change.**

## Things that can still be improved:
+ [X] Fix subcommand names that are hyphenated
+ [ ] Automatically downcase the names of subcommands for help messages (this could also apply to `#[derive(StructOpt)]` on structs or to changing argument names from `_` to `-`)
+ [x] Add the ability to use `about` attribute/doc comments on subcommand variants for help messages
+ [x] Allow other enum variant types than curly-bracketed ones (e.g. "blank" subcommands)

## Other stuff

There are some commits that don't technically have anything to do with adding subcommands in:

+ Add documentation for the PR that added doc comments for help messages a few weeks ago
+ Add a link from the `structopt` documentation to the `structopt-derive` documentation
+ Bump versions of `structopt` and `structopt-derive` to 0.1.0
+ Edit the `structopt-derive` documentation for clarity

Detailed documentation has been added to the `structopt-derive` crate specifying how to use the new subcommand functionality. Reproduced here:

## Subcomamnds

Some applications, like `git`, support "subcommands;" an extra command that
is used to differentiate what the application should do. With `git`, these
would be `add`, `init`, `fetch`, `commit`, for a few examples.

`clap` has this functionality, so `structopt` supports this through enums:

```rust
#[derive(StructOpt)]
#[structopt(name = "git", about = "the stupid content tracker")]
enum Git {
    #[structopt(name = "add")]
    Add {
        #[structopt(short = "i")]
        interactive: bool,
        #[structopt(short = "p")]
        patch: bool,
        files: Vec<String>
    },
    #[structopt(name = "fetch")]
    Fetch {
        #[structopt(long = "dry-run")]
        dry_run: bool,
        #[structopt(long = "all")]
        all: bool,
        repository: Option<String>
    },
    #[structopt(name = "commit")]
    Commit {
        #[structopt(short = "m")]
        message: Option<String>,
        #[structopt(short = "a")]
        all: bool
    }
}
```

Using `derive(StructOpt)` on an enum instead of a struct will produce
a `clap::App` that only takes subcommands. So `git add`, `git fetch`,
and `git commit` would be commands allowed for the above example.

`structopt` also provides support for applications where certain flags
need to apply to all subcommands, as well as nested subcommands:

```rust
#[derive(StructOpt)]
#[structopt(name = "make-cookie")]
struct MakeCookie {
    #[structopt(name = "supervisor", default_value = "Puck", required = false, long = "supervisor")]
    supervising_faerie: String,
    #[structopt(name = "tree")]
    /// The faerie tree this cookie is being made in.
    tree: Option<String>,
    #[structopt(subcommand)]  // Note that we mark a field as a subcommand
    cmd: Command
}

#[derive(StructOpt)]
enum Command {
    #[structopt(name = "pound")]
    /// Pound acorns into flour for cookie dough.
    Pound {
        acorns: u32
    },
    #[structopt(name = "sparkle")]
    /// Add magical sparkles -- the secret ingredient!
    Sparkle {
        #[structopt(short = "m")]
        magicality: u64,
        #[structopt(short = "c")]
        color: String
    },
    #[structopt(name = "finish")]
    Finish {
        #[structopt(short = "t")]
        time: u32,
        #[structopt(subcommand)]  // Note that we mark a field as a subcommand
        type: FinishType
    }
}

#[derive(StructOpt)]
enum FinishType {
    #[structopt(name = "glaze")]
    Glaze {
        applications: u32
    },
    #[structopt(name = "powder")]
    Powder {
        flavor: String,
        dips: u32
    }
}
```

Marking a field with `structopt(subcommand)` will add the subcommands of the
designated enum to the current `clap::App`. The designated enum *must* also
be derived `StructOpt`. So the above example would take the following
commands:

+ `make-cookie pound 50`
+ `make-cookie sparkle -mmm --color "green"`
+ `make-cookie finish 130 glaze 3`

### Optional subcommands

A nested subcommand can be marked optional:

```rust
#[derive(StructOpt)]
#[structopt(name = "foo")]
struct Foo {
    file: String,
    #[structopt(subcommand)]
    cmd: Option<Command>
}

#[derive(StructOpt)]
enum Command {
    Bar,
    Baz,
    Quux
}
```
