### PR TITLE
Add raw attributes

### DIFF
--- a/examples/raw_attributes.rs
+++ b/examples/raw_attributes.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Guillaume Pinot <texitoi(a)texitoi.eu>
+//
+// This work is free. You can redistribute it and/or modify it under
+// the terms of the Do What The Fuck You Want To Public License,
+// Version 2, as published by Sam Hocevar. See the COPYING file for
+// more details.
+
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
+
+use structopt::StructOpt;
+use structopt::clap::AppSettings;
+
+/// An example of raw attributes
+#[derive(StructOpt, Debug)]
+#[structopt(global_settings_raw = "&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]")]
+struct Opt {
+    /// Output file
+    #[structopt(short = "o", long = "output")]
+    output: String,
+
+    /// admin_level to consider
+    #[structopt(short = "l", long = "level", aliases_raw = "&[\"set-level\", \"lvl\"]")]
+    level: Vec<String>,
+
+    /// Files to process
+    ///
+    /// `level` is required if a file is called `FILE`.
+    #[structopt(name = "FILE", requires_if_raw = "\"FILE\", \"level\"")]
+    files: Vec<String>,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
+}

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -48,6 +48,8 @@
 //! through specifying it as an attribute.
 //! The `name` attribute can be used to customize the
 //! `Arg::with_name()` call (defaults to the field name).
+//! For functions that do not take a `&str` as argument, the attribute can be
+//! called `function_name_raw`, e. g. `aliases_raw = "&[\"alias\"]"`.
 //!
 //! The type of the field gives the kind of argument:
 //!
@@ -392,7 +394,7 @@ fn gen_augmentation(fields: &[Field], app_var: &Ident) -> quote::Tokens {
             };
             let from_attr = extract_attrs(&field.attrs, AttrSource::Field)
                 .filter(|&(ref i, _)| i.as_ref() != "name")
-                .map(|(i, l)| quote!(.#i(#l)));
+                .map(|(i, l)| gen_attr_call(&i, &l));
             quote!( .arg(_structopt::clap::Arg::with_name(stringify!(#name)) #modifier #(#from_attr)*) )
         });
 
@@ -402,6 +404,20 @@ fn gen_augmentation(fields: &[Field], app_var: &Ident) -> quote::Tokens {
         #( #subcmds )*
         #app_var
     }}
+}
+
+/// Interpret the value of `*_raw` attributes as code and the rest as strings.
+fn gen_attr_call(key: &syn::Ident, val: &syn::Lit) -> quote::Tokens {
+    if let Lit::Str(ref val, _) = *val {
+        let key = key.as_ref();
+        if key.ends_with("_raw") {
+            let key = Ident::from(&key[..(key.len() - 4)]);
+            // Call method without quoting the string
+            let ts = syn::parse_token_trees(val).unwrap();
+            return quote!(.#key(#(#ts)*));
+        }
+    }
+    quote!(.#key(#val))
 }
 
 fn gen_constructor(fields: &[Field]) -> quote::Tokens {
@@ -480,12 +496,28 @@ fn format_author(raw_authors: Lit) -> Lit {
     Lit::Str(authors, StrStyle::Cooked)
 }
 
-fn gen_clap(struct_attrs: &[Attribute], subcmd_required: bool) -> quote::Tokens {
-    let struct_attrs: Vec<_> = extract_attrs(struct_attrs, AttrSource::Struct).collect();
-    let name = from_attr_or_env(&struct_attrs, "name", "CARGO_PKG_NAME");
-    let version = from_attr_or_env(&struct_attrs, "version", "CARGO_PKG_VERSION");
-    let author = format_author(from_attr_or_env(&struct_attrs, "author", "CARGO_PKG_AUTHORS"));
-    let about = from_attr_or_env(&struct_attrs, "about", "CARGO_PKG_DESCRIPTION");
+fn gen_clap(attrs: &[Attribute]) -> quote::Tokens {
+    let attrs: Vec<_> = extract_attrs(attrs, AttrSource::Struct).collect();
+    let name = from_attr_or_env(&attrs, "name", "CARGO_PKG_NAME");
+    let version = from_attr_or_env(&attrs, "version", "CARGO_PKG_VERSION");
+    let author = format_author(from_attr_or_env(&attrs, "author", "CARGO_PKG_AUTHORS"));
+    let about = from_attr_or_env(&attrs, "about", "CARGO_PKG_DESCRIPTION");
+    let settings = attrs.iter()
+        .filter(|&&(ref i, _)| !["name", "version", "auther", "about"].contains(&i.as_ref()))
+        .map(|&(ref i, ref l)| gen_attr_call(i, l))
+        .collect::<Vec<_>>();
+
+    quote! {
+        _structopt::clap::App::new(#name)
+            .version(#version)
+            .author(#author)
+            .about(#about)
+            #( #settings )*
+    }
+}
+
+fn gen_clap_struct(struct_attrs: &[Attribute], subcmd_required: bool) -> quote::Tokens {
+    let gen = gen_clap(struct_attrs);
     let setting = if subcmd_required {
         quote!( .setting(_structopt::clap::AppSettings::SubcommandRequired) )
     } else {
@@ -494,12 +526,8 @@ fn gen_clap(struct_attrs: &[Attribute], subcmd_required: bool) -> quote::Tokens 
 
     quote! {
         fn clap<'a, 'b>() -> _structopt::clap::App<'a, 'b> {
-            let app = _structopt::clap::App::new(#name)
-                .version(#version)
-                .author(#author)
-                .about(#about)
-                #setting
-                ;
+            let app = #gen
+                #setting;
             Self::augment_clap(app)
         }
     }
@@ -516,19 +544,11 @@ fn gen_augment_clap(fields: &[Field]) -> quote::Tokens {
 }
 
 fn gen_clap_enum(enum_attrs: &[Attribute]) -> quote::Tokens {
-    let enum_attrs: Vec<_> = extract_attrs(enum_attrs, AttrSource::Struct).collect();
-    let name = from_attr_or_env(&enum_attrs, "name", "CARGO_PKG_NAME");
-    let version = from_attr_or_env(&enum_attrs, "version", "CARGO_PKG_VERSION");
-    let author = format_author(from_attr_or_env(&enum_attrs, "author", "CARGO_PKG_AUTHORS"));
-    let about = from_attr_or_env(&enum_attrs, "about", "CARGO_PKG_DESCRIPTION");
-
+    let gen = gen_clap(enum_attrs);
     quote! {
         fn clap<'a, 'b>() -> _structopt::clap::App<'a, 'b> {
-            let app = _structopt::clap::App::new(#name)
-                .version(#version)
-                .author(#author)
-                .about(#about)
-                .setting(_structopt::clap::AppSettings::SubcommandRequired);
+            let app = #gen
+                .setting(_structopt::clap::AppSettings::SubcommandRequiredElseHelp);
             Self::augment_clap(app)
         }
     }
@@ -552,7 +572,7 @@ fn gen_augment_clap_enum(variants: &[Variant]) -> quote::Tokens {
         };
         let from_attr = extract_attrs(&variant.attrs, AttrSource::Struct)
             .filter(|&(ref i, _)| i != "name")
-            .map(|(i, l)| quote!( .#i(#l) ));
+            .map(|(i, l)| gen_attr_call(&i, &l));
 
         quote! {
             .subcommand({
@@ -620,7 +640,7 @@ fn impl_structopt_for_struct(name: &Ident, fields: &[Field], attrs: &[Attribute]
             _ => is_subcommand(field)
         }
     });
-    let clap = gen_clap(attrs, subcmd_required);
+    let clap = gen_clap_struct(attrs, subcmd_required);
     let augment_clap = gen_augment_clap(fields);
     let from_clap = gen_from_clap(name, fields);
 

--- a/tests/raw_attributes.rs
+++ b/tests/raw_attributes.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Guillaume Pinot <texitoi(a)texitoi.eu>
+//
+// This work is free. You can redistribute it and/or modify it under
+// the terms of the Do What The Fuck You Want To Public License,
+// Version 2, as published by Sam Hocevar. See the COPYING file for
+// more details.
+
+extern crate structopt;
+#[macro_use]
+extern crate structopt_derive;
+
+use structopt::StructOpt;
+use structopt::clap::AppSettings;
+
+// Check if the global settings compile
+#[derive(StructOpt, Debug, PartialEq, Eq)]
+#[structopt(global_settings_raw = "&[AppSettings::ColoredHelp]")]
+struct Opt {
+    #[structopt(long = "x", display_order_raw = "2", next_line_help_raw = "true",
+        default_value_raw = "\"0\"", require_equals_raw = "true")]
+    x: i32,
+
+    #[structopt(short = "l", long = "level", aliases_raw = "&[\"set-level\", \"lvl\"]")]
+    level: String,
+
+    #[structopt(long = "values")]
+    values: Vec<i32>,
+
+    #[structopt(name = "FILE", requires_if_raw = "\"FILE\", \"values\"")]
+    files: Vec<String>,
+}
+
+#[test]
+fn test_raw_slice() {
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: Vec::new(), values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-l", "1"])));
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: Vec::new(), values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "--level", "1"])));
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: Vec::new(), values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "--set-level", "1"])));
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: Vec::new(), values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "--lvl", "1"])));
+}
+
+#[test]
+fn test_raw_multi_args() {
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: vec!["file".to_string()], values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-l", "1", "file"])));
+    assert_eq!(Opt { x: 0, level: "1".to_string(), files: vec!["FILE".to_string()], values: vec![1] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-l", "1", "--values", "1", "--", "FILE"])));
+}
+
+#[test]
+fn test_raw_multi_args_fail() {
+    let result = Opt::clap().get_matches_from_safe(&["test", "-l", "1", "--", "FILE"]);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_raw_bool() {
+    assert_eq!(Opt { x: 1, level: "1".to_string(), files: vec![], values: vec![] },
+               Opt::from_clap(Opt::clap().get_matches_from(&["test", "-l", "1", "--x=1"])));
+    let result = Opt::clap().get_matches_from_safe(&["test", "-l", "1", "--x", "1"]);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This makes it possible to call clap functions that don't take strings,
but any arbitrary value. Even functions that take more than one argument
can be called.

All attributes that are called `attribute_name_raw` are augmented to
`attribute_name(value)` without quoting `value`.

This fixes #4.

For enums, I changed `AppSettings::SubcommandRequired` to `AppSettings::SubcommandRequiredElseHelp` if that's ok?
I find it much more useful if an application lists the help instead of telling me to get the help manually.
Unfortunately this behaviour of structopt cannot be overwritten by the user (no matter which one is used).