### PR TITLE
Allow opting out of clap default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structopt"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parse command line argument by defining a struct."
 documentation = "https://docs.rs/structopt"
@@ -10,11 +10,14 @@ categories = ["command-line-interface"]
 license = "WTFPL"
 readme = "README.md"
 
+[features]
+default = ["clap/default"]
+
 [badges]
 travis-ci = { repository = "TeXitoi/structopt" }
 
 [dependencies]
-clap = "2.20"
+clap = { version = "2.20", default-features = false }
 
 [dev-dependencies]
 structopt-derive = { path = "structopt-derive", version = "0.1.6" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,15 @@
 //! little interest.  See the 
 //! [`structopt-derive`](https://docs.rs/structopt-derive) crate to
 //! automatically generate an implementation of this trait.
+//!
+//! If you want to disable all the `clap` features (colors,
+//! suggestions, ..) add `default-features = false` to the `structopt`
+//! dependency:
+//! ```toml
+//! [dependencies]
+//! structopt = { version = "0.1.0", default-features = false }
+//! structopt-derive = "0.1.0"
+//! ```
 
 extern crate clap as _clap;
 


### PR DESCRIPTION
Clap comes with some colorful default features, which are not always useful or wanted, so allow opting out of them.