### PR TITLE
Use proper path to 'PathBuf' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And then, in your rust file:
 #[macro_use]
 extern crate structopt;
 
-use std::fs::PathBuf;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 /// A basic example


### PR DESCRIPTION
`PathBuf` is in `std::path`, not `std::fs`.