### PR TITLE
Use `proc_macro2::Span::call_site` for all quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ rust:
   - beta
   - nightly
 matrix:
+  include:
+    - rust: nightly
+      env: FEATURES="--features testing_only_proc_macro2_nightly"
   allow_failures:
     - rust: nightly
+
+script:
+  - cargo test $FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Work around breakage when `proc-macro2`'s nightly feature is enabled. ([#77](https://github.com/Texitoi/structopt/pull/77) and [proc-macro2#67](https://github.com/alexcrichton/proc-macro2/issues/67))
+
 # v0.2.4 (2018-02-25)
 
 * Fix compilation with `#![deny(missig_docs]` ([#74](https://github.com/TeXitoi/structopt/issues/74)) by [@TeXitoi](https://github.com/TeXitoi)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [features]
 default = ["clap/default"]
+testing_only_proc_macro2_nightly = ["structopt-derive/testing_only_proc_macro2_nightly"]
 
 [badges]
 travis-ci = { repository = "TeXitoi/structopt" }

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -17,5 +17,8 @@ syn = "0.12"
 quote = "0.4"
 proc-macro2 = "0.2"
 
+[features]
+testing_only_proc_macro2_nightly = ["proc-macro2/nightly"]
+
 [lib]
 proc-macro = true

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -16,6 +16,9 @@ extern crate syn;
 extern crate quote;
 extern crate proc_macro2;
 
+#[macro_use]
+mod macros;
+
 mod attrs;
 
 use proc_macro::TokenStream;
@@ -94,12 +97,12 @@ fn gen_augmentation(fields: &Punctuated<Field, Comma>, app_var: &Ident) -> quote
                 _ => &field.ty
             };
             let required = if cur_type == Ty::Option {
-                quote!()
+                my_quote!()
             } else {
-                quote!( let #app_var = #app_var.setting(::structopt::clap::AppSettings::SubcommandRequiredElseHelp); )
+                my_quote!( let #app_var = #app_var.setting(::structopt::clap::AppSettings::SubcommandRequiredElseHelp); )
             };
 
-            quote!{
+            my_quote!{
                 let #app_var = #subcmd_type ::augment_clap( #app_var );
                 #required
             }
@@ -124,35 +127,35 @@ fn gen_augmentation(fields: &Punctuated<Field, Comma>, app_var: &Ident) -> quote
             }
 
             let validator = match *attrs.parser() {
-                (Parser::TryFromStr, ref f) => quote! {
+                (Parser::TryFromStr, ref f) => my_quote! {
                     .validator(|s| {
                         #f(&s)
                             .map(|_: #convert_type| ())
                             .map_err(|e| e.to_string())
                     })
                 },
-                (Parser::TryFromOsStr, ref f) => quote! {
+                (Parser::TryFromOsStr, ref f) => my_quote! {
                     .validator_os(|s| #f(&s).map(|_: #convert_type| ()))
                 },
-                _ => quote!(),
+                _ => my_quote!(),
             };
 
             let modifier = match cur_type {
-                Ty::Bool => quote!( .takes_value(false).multiple(false) ),
-                Ty::Option => quote!( .takes_value(true).multiple(false) #validator ),
-                Ty::Vec => quote!( .takes_value(true).multiple(true) #validator ),
-                Ty::Other if occurences => quote!( .takes_value(false).multiple(true) ),
+                Ty::Bool => my_quote!( .takes_value(false).multiple(false) ),
+                Ty::Option => my_quote!( .takes_value(true).multiple(false) #validator ),
+                Ty::Vec => my_quote!( .takes_value(true).multiple(true) #validator ),
+                Ty::Other if occurences => my_quote!( .takes_value(false).multiple(true) ),
                 Ty::Other => {
                     let required = !attrs.has_method("default_value");
-                    quote!( .takes_value(true).multiple(false).required(#required) #validator )
+                    my_quote!( .takes_value(true).multiple(false).required(#required) #validator )
                 },
             };
             let methods = attrs.methods();
             let name = attrs.name();
-            Some(quote!(.arg(::structopt::clap::Arg::with_name(#name)#modifier#methods)))
+            Some(my_quote!(.arg(::structopt::clap::Arg::with_name(#name)#modifier#methods)))
         });
 
-    quote! {{
+    my_quote! {{
         let #app_var = #app_var #( #args )* ;
         #( #subcmds )*
         #app_var
@@ -170,10 +173,10 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>) -> quote::Tokens {
                 _ => &field.ty
             };
             let unwrapper = match cur_type {
-                Ty::Option => quote!(),
-                _ => quote!( .unwrap() )
+                Ty::Option => my_quote!(),
+                _ => my_quote!( .unwrap() )
             };
-            quote!(#field_name: #subcmd_type::from_subcommand(matches.subcommand())#unwrapper)
+            my_quote!(#field_name: #subcmd_type::from_subcommand(matches.subcommand())#unwrapper)
         } else {
             let real_ty = &field.ty;
             let mut cur_type = ty(real_ty);
@@ -183,45 +186,45 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>) -> quote::Tokens {
 
             use Parser::*;
             let (value_of, values_of, parse) = match *attrs.parser() {
-                (FromStr, ref f) => (quote!(value_of), quote!(values_of), f.clone()),
+                (FromStr, ref f) => (my_quote!(value_of), my_quote!(values_of), f.clone()),
                 (TryFromStr, ref f) =>
-                    (quote!(value_of), quote!(values_of), quote!(|s| #f(s).unwrap())),
+                    (my_quote!(value_of), my_quote!(values_of), my_quote!(|s| #f(s).unwrap())),
                 (FromOsStr, ref f) =>
-                    (quote!(value_of_os), quote!(values_of_os), f.clone()),
+                    (my_quote!(value_of_os), my_quote!(values_of_os), f.clone()),
                 (TryFromOsStr, ref f) =>
-                    (quote!(value_of_os), quote!(values_of_os), quote!(|s| #f(s).unwrap())),
-                (FromOccurrences, ref f) => (quote!(occurrences_of), quote!(), f.clone()),
+                    (my_quote!(value_of_os), my_quote!(values_of_os), my_quote!(|s| #f(s).unwrap())),
+                (FromOccurrences, ref f) => (my_quote!(occurrences_of), my_quote!(), f.clone()),
             };
 
             let occurences = attrs.parser().0 == Parser::FromOccurrences;
             let name = attrs.name();
             let field_value = match cur_type {
-                Ty::Bool => quote!(matches.is_present(#name)),
-                Ty::Option => quote! {
+                Ty::Bool => my_quote!(matches.is_present(#name)),
+                Ty::Option => my_quote! {
                     matches.#value_of(#name)
                         .as_ref()
                         .map(#parse)
                 },
-                Ty::Vec => quote! {
+                Ty::Vec => my_quote! {
                     matches.#values_of(#name)
                         .map(|v| v.map(#parse).collect())
                         .unwrap_or_else(Vec::new)
                 },
-                Ty::Other if occurences => quote! {
+                Ty::Other if occurences => my_quote! {
                     #parse(matches.#value_of(#name))
                 },
-                Ty::Other => quote! {
+                Ty::Other => my_quote! {
                     matches.#value_of(#name)
                         .map(#parse)
                         .unwrap()
                 },
             };
 
-            quote!( #field_name: #field_value )
+            my_quote!( #field_name: #field_value )
         }
     });
 
-    quote! {{
+    my_quote! {{
         #( #fields ),*
     }}
 }
@@ -229,7 +232,7 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>) -> quote::Tokens {
 fn gen_from_clap(struct_name: &Ident, fields: &Punctuated<Field, Comma>) -> quote::Tokens {
     let field_block = gen_constructor(fields);
 
-    quote! {
+    my_quote! {
         fn from_clap(matches: &::structopt::clap::ArgMatches) -> Self {
             #struct_name #field_block
         }
@@ -241,12 +244,12 @@ fn gen_clap(attrs: &[Attribute]) -> quote::Tokens {
     let attrs = Attrs::from_struct(attrs, name);
     let name = attrs.name();
     let methods = attrs.methods();
-    quote!(::structopt::clap::App::new(#name)#methods)
+    my_quote!(::structopt::clap::App::new(#name)#methods)
 }
 
 fn gen_clap_struct(struct_attrs: &[Attribute]) -> quote::Tokens {
     let gen = gen_clap(struct_attrs);
-    quote! {
+    my_quote! {
         fn clap<'a, 'b>() -> ::structopt::clap::App<'a, 'b> {
             let app = #gen;
             Self::augment_clap(app)
@@ -257,7 +260,7 @@ fn gen_clap_struct(struct_attrs: &[Attribute]) -> quote::Tokens {
 fn gen_augment_clap(fields: &Punctuated<Field, Comma>) -> quote::Tokens {
     let app_var: Ident = "app".into();
     let augmentation = gen_augmentation(fields, &app_var);
-    quote! {
+    my_quote! {
         pub fn augment_clap<'a, 'b>(#app_var: ::structopt::clap::App<'a, 'b>) -> ::structopt::clap::App<'a, 'b> {
             #augmentation
         }
@@ -266,7 +269,7 @@ fn gen_augment_clap(fields: &Punctuated<Field, Comma>) -> quote::Tokens {
 
 fn gen_clap_enum(enum_attrs: &[Attribute]) -> quote::Tokens {
     let gen = gen_clap(enum_attrs);
-    quote! {
+    my_quote! {
         fn clap<'a, 'b>() -> ::structopt::clap::App<'a, 'b> {
             let app = #gen
                 .setting(::structopt::clap::AppSettings::SubcommandRequiredElseHelp);
@@ -284,10 +287,10 @@ fn gen_augment_clap_enum(variants: &Punctuated<Variant, Comma>) -> quote::Tokens
         let app_var: Ident = "subcommand".into();
         let arg_block = match variant.fields {
             Named(ref fields) => gen_augmentation(&fields.named, &app_var),
-            Unit => quote!( #app_var ),
+            Unit => my_quote!( #app_var ),
             Unnamed(FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
                 let ty = &unnamed[0];
-                quote! {
+                my_quote! {
                     {
                         let #app_var = #ty::augment_clap(#app_var);
                         if #ty::is_subcommand() {
@@ -303,7 +306,7 @@ fn gen_augment_clap_enum(variants: &Punctuated<Variant, Comma>) -> quote::Tokens
 
         let name = attrs.name();
         let from_attrs = attrs.methods();
-        quote! {
+        my_quote! {
             .subcommand({
                 let #app_var = ::structopt::clap::SubCommand::with_name(#name);
                 let #app_var = #arg_block;
@@ -312,7 +315,7 @@ fn gen_augment_clap_enum(variants: &Punctuated<Variant, Comma>) -> quote::Tokens
         }
     });
 
-    quote! {
+    my_quote! {
         pub fn augment_clap<'a, 'b>(app: ::structopt::clap::App<'a, 'b>) -> ::structopt::clap::App<'a, 'b> {
             app #( #subcommands )*
         }
@@ -320,7 +323,7 @@ fn gen_augment_clap_enum(variants: &Punctuated<Variant, Comma>) -> quote::Tokens
 }
 
 fn gen_from_clap_enum(name: &Ident) -> quote::Tokens {
-    quote! {
+    my_quote! {
         fn from_clap(matches: &::structopt::clap::ArgMatches) -> Self {
             #name ::from_subcommand(matches.subcommand())
                 .unwrap()
@@ -337,22 +340,22 @@ fn gen_from_subcommand(name: &Ident, variants: &Punctuated<Variant, Comma>) -> q
         let variant_name = &variant.ident;
         let constructor_block = match variant.fields {
             Named(ref fields) => gen_constructor(&fields.named),
-            Unit => quote!(),
+            Unit => my_quote!(),
             Unnamed(ref fields) if fields.unnamed.len() == 1 => {
                 let ty = &fields.unnamed[0];
-                quote!( ( <#ty as ::structopt::StructOpt>::from_clap(matches) ) )
+                my_quote!( ( <#ty as ::structopt::StructOpt>::from_clap(matches) ) )
             }
             Unnamed(..) =>
                 panic!("{}: tuple enum are not supported", variant.ident),
         };
 
-        quote! {
+        my_quote! {
             (#sub_name, Some(matches)) =>
                 Some(#name :: #variant_name #constructor_block)
         }
     });
 
-    quote! {
+    my_quote! {
         pub fn from_subcommand<'a, 'b>(sub: (&'b str, Option<&'b ::structopt::clap::ArgMatches<'a>>)) -> Option<Self> {
             match sub {
                 #( #match_arms ),*,
@@ -371,7 +374,7 @@ fn impl_structopt_for_struct(
     let augment_clap = gen_augment_clap(fields);
     let from_clap = gen_from_clap(name, fields);
 
-    quote! {
+    my_quote! {
         #[allow(unused_variables)]
         impl ::structopt::StructOpt for #name {
             #clap
@@ -397,7 +400,7 @@ fn impl_structopt_for_enum(
     let from_clap = gen_from_clap_enum(name);
     let from_subcommand = gen_from_subcommand(name, variants);
 
-    quote! {
+    my_quote! {
         impl ::structopt::StructOpt for #name {
             #clap
             #from_clap
@@ -425,5 +428,5 @@ fn impl_structopt(input: &DeriveInput) -> quote::Tokens {
         _ => panic!("structopt only supports non-tuple structs and enums")
     };
 
-    quote!(#inner_impl)
+    my_quote!(#inner_impl)
 }

--- a/structopt-derive/src/macros.rs
+++ b/structopt-derive/src/macros.rs
@@ -1,0 +1,11 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! my_quote {
+    ($($t:tt)*) => (quote_spanned!(::proc_macro2::Span::call_site() => $($t)*))
+}


### PR DESCRIPTION
This avoids breakage when deriving `StructOpt` when `proc_macro2`'s nightly feature is enabled. See https://github.com/alexcrichton/proc-macro2/issues/67 for details.

cc @alexcrichton