### PR TITLE
Fix raw() sample code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,10 @@
 //! #[macro_use]
 //! extern crate structopt;
 //!
-//! use structopt::StructOpt;
+//! use structopt::{clap, StructOpt};
 //!
 //! #[derive(StructOpt, Debug)]
-//! #[structopt(raw(setting = "structopt::clap::AppSettings::ColoredHelp"))]
+//! #[structopt(raw(setting = "clap::AppSettings::ColoredHelp"))]
 //! struct Opt {
 //!     #[structopt(short = "s")]
 //!     speed: bool,


### PR DESCRIPTION
The sample code seems to be wrong.
The following error occurred.

```
error[E0433]: failed to resolve. Use of undeclared type or module `structopt`
  --> src/main.rs:16:10
   |
16 | #[derive(StructOpt, Debug)]
   |          ^^^^^^^^^ Use of undeclared type or module `structopt`
```