### PR TITLE
fix Cargo authors list insertion code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "structopt"
 version = "0.2.8"
-authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
+authors = ["Guillaume Pinot <texitoi@texitoi.eu>", "others"]
 description = "Parse command line argument by defining a struct."
 documentation = "https://docs.rs/structopt"
 repository = "https://github.com/TeXitoi/structopt"

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -228,8 +228,12 @@ impl Attrs {
             .filter_map(|&(m, v)| env::var(v).ok().and_then(|arg| Some((m, arg))))
             .filter(|&(_, ref arg)| !arg.is_empty())
             .for_each(|(name, arg)| {
-                if arg == "author" { arg.replace(":", ", "); }
-                res.push_str_method(name, &arg);
+                let new_arg = if name == "author" {
+                    arg.replace(":", ", ")
+                } else {
+                    arg
+                };
+                res.push_str_method(name, &new_arg);
             });
         res.push_doc_comment(attrs, "about");
         res.push_attrs(attrs);

--- a/tests/author_version_about.rs
+++ b/tests/author_version_about.rs
@@ -33,6 +33,6 @@ fn use_env() {
     Opt::clap().write_long_help(&mut output).unwrap();
     let output = String::from_utf8(output).unwrap();
     assert!(output.starts_with("structopt 0.2."));
-    assert!(output.contains("Guillaume Pinot <texitoi@texitoi.eu>"));
+    assert!(output.contains("Guillaume Pinot <texitoi@texitoi.eu>, others"));
     assert!(output.contains("Parse command line argument by defining a struct."));
 }


### PR DESCRIPTION
Nice crate.
Fix code to transform a list of authors. It was doing no change, leaving colon separated list.
Style it as you like it.
I don't know how to test without also modifying the real authors list in Cargo.toml.
Ideas?