### PR TITLE
fully qualify StructOpt when flattening

### DIFF
--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -177,7 +177,7 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>) -> TokenStream {
                 };
                 quote!(#field_name: <#subcmd_type>::from_subcommand(matches.subcommand())#unwrapper)
             }
-            Kind::FlattenStruct => quote!(#field_name: StructOpt::from_clap(matches)),
+            Kind::FlattenStruct => quote!(#field_name: ::structopt::StructOpt::from_clap(matches)),
             Kind::Arg(ty) => {
                 use Parser::*;
                 let (value_of, values_of, parse) = match *attrs.parser() {


### PR DESCRIPTION
This fixes a bug when a module is missing `use structopt::StructOpt`
which would result in the following error:

```
  |
7 | #[derive(Debug, StructOpt)]
  |                 ^^^^^^^^^ Use of undeclared type or module `StructOpt`
```