### PR TITLE
Simplify `group` example

### DIFF
--- a/examples/simple_group.rs
+++ b/examples/simple_group.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate structopt;
+
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct Opt {
+    /// Set a custom HTTP verb
+    #[structopt(long = "method", group = "verb")]
+    method: Option<String>,
+    /// HTTP GET; default if no other HTTP verb is selected
+    #[structopt(long = "get", group = "verb")]
+    get: bool,
+    /// HTTP HEAD
+    #[structopt(long = "head", group = "verb")]
+    head: bool,
+    /// HTTP POST
+    #[structopt(long = "post", group = "verb")]
+    post: bool,
+    /// HTTP PUT
+    #[structopt(long = "put", group = "verb")]
+    put: bool,
+    /// HTTP DELETE
+    #[structopt(long = "delete", group = "verb")]
+    delete: bool,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
+}


### PR DESCRIPTION
This does change the behavior of the `group` example. The `vers` group is no longer required. It is is still a group, that is: only one of the several options are accepted.

I'm not sure this is an improvement to the example. It is much simpler and aligns with the ways I usually use groups, where they are not required.