### PR TITLE
Upgrade syn to 0.15

### DIFF
--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0/MIT"
 travis-ci = { repository = "TeXitoi/structopt" }
 
 [dependencies]
-syn = "0.14"
+syn = "0.15"
 quote = "0.6"
 proc-macro2 = "0.4"
 


### PR DESCRIPTION
This removes the dependency on syn 0.14 in downstream creates, which means you don't need to compile syn 0.14 and 0.15. Surprisingly, this update worked by just increasing the version number.