### PR TITLE
Introduce smarter parsing of doc comments.

### DIFF
--- a/examples/doc_comments.rs
+++ b/examples/doc_comments.rs
@@ -1,0 +1,86 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[macro_use]
+extern crate structopt;
+
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+/// A basic example for the usage of doc comments as replacement
+/// of the arguments `help`, `long_help`, `about` and `long_about`.
+#[derive(StructOpt, Debug)]
+#[structopt(name = "basic")]
+struct Opt {
+    /// Just use doc comments to replace `help`, `long_help`,
+    /// `about` or `long_about` input.
+    #[structopt(short = "f", long = "first-flag")]
+    first_flag: bool,
+
+    /// Split between `help` and `long_help`.
+    ///
+    /// In the previous case structopt is going to present
+    /// the whole comment both as text for the `help` and the
+    /// `long_help` argument.
+    ///
+    /// But if the doc comment is formatted like this example
+    /// -- with an empty second line splitting the heading and
+    /// the rest of the comment -- only the first line is used
+    /// as `help` argument. The `long_help` argument will still
+    /// contain the whole comment.
+    ///
+    /// ## Attention
+    ///
+    /// Any formatting next to empty lines that could be used
+    /// inside a doc comment is currently not preserved. If
+    /// lists or other well formatted content is required it is
+    /// necessary to use the related structopt argument with a
+    /// raw string as shown on the `third_flag` description.
+    #[structopt(short = "s", long = "second-flag")]
+    second_flag: bool,
+
+    #[structopt(
+        short = "t",
+        long = "third-flag",
+        long_help = r"This is a raw string.
+
+It can be used to pass well formatted content (e.g. lists or source
+code) in the description:
+
+ - first example list entry
+ - second example list entry
+ "
+    )]
+    third_flag: bool,
+
+    #[structopt(subcommand)]
+    sub_command: SubCommand,
+}
+
+#[derive(StructOpt, Debug)]
+#[structopt()]
+enum SubCommand {
+    /// The same rules described previously for flags. Are
+    /// also true for in regards of sub-commands.
+    #[structopt(name = "first")]
+    First,
+
+    /// Applicable for both `about` an `help`.
+    ///
+    /// The formatting rules described in the comment of the
+    /// `second_flag` also apply to the description of
+    /// sub-commands which is normally given through the `about`
+    /// and `long_about` arguments.
+    #[structopt(name = "second")]
+    Second,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
+}

--- a/examples/enum_in_args.rs
+++ b/examples/enum_in_args.rs
@@ -17,12 +17,10 @@ arg_enum! {
 #[derive(StructOpt, Debug)]
 struct Opt {
     /// Important argument.
-    #[structopt(
-        raw(
-            possible_values = "&Baz::variants()",
-            case_insensitive = "true"
-        )
-    )]
+    #[structopt(raw(
+        possible_values = "&Baz::variants()",
+        case_insensitive = "true"
+    ))]
     i: Baz,
 }
 

--- a/examples/raw_attributes.rs
+++ b/examples/raw_attributes.rs
@@ -14,9 +14,9 @@ use structopt::StructOpt;
 
 /// An example of raw attributes
 #[derive(StructOpt, Debug)]
-#[structopt(
-    raw(global_settings = "&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]")
-)]
+#[structopt(raw(
+    global_settings = "&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]"
+))]
 struct Opt {
     /// Output file
     #[structopt(short = "o", long = "output")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,43 @@
 //! # fn main() {}
 //! ```
 //!
+//! If it is necessary or wanted to provide a more complex help message then the
+//! previous used ones, it could still be a good idea to distinguish between the
+//! actual help message a short summary. In this case `about` and `help` should
+//! only contain the short and concise form while the two additional arguments
+//! `long_about` and `long_help` can be used to store a descriptive and more in
+//! depth message.
+//!
+//! If both - the short and the long version of the argument - are present,
+//! the user can later chose between the short summary (`-h`) and the long
+//! descriptive version (`--help`) of the help message. Also in case
+//! of subcommands the short help message will automatically be used for the
+//! command description inside the parents help message and the long version
+//! as command description if help is requested on the actual subcommand.
+//!
+//! This feature can also be used with doc comments instead of arguments through
+//! proper comment formatting. To be activated it requires, that the first line
+//! of the comment is separated from the rest of the comment through an empty line.
+//! In this case the first line is used as summary and the whole comment represents
+//! the long descriptive message.
+//!
+//! ```
+//! # #[macro_use] extern crate structopt;
+//! #[derive(StructOpt)]
+//! #[structopt(name = "foo")]
+//! /// The help message that will be displayed when passing `--help`.
+//! struct Foo {
+//!   #[structopt(short = "b")]
+//!   /// Only this summary is visible when passing `-h`.
+//!   ///
+//!   /// But the whole comment will be displayed when passing `--help`.
+//!   /// This could be quite useful to provide further hints are usage
+//!   /// examples.
+//!   bar: String
+//! }
+//! # fn main() {}
+//! ```
+//!
 //! ## Subcommands
 //!
 //! Some applications, especially large ones, split their functionality


### PR DESCRIPTION
First approach of an implementation of the smarter doc comment parsing feature requested in #134.

It introduces an additional check in the doc comment parsing algorithm to test if the second line of a given doc comment is an empty line. If this is true only the first line will be used as input for the argument given as input parameter (`help` or `about`) at the same time it applies the whole comment as input for the related long version (`long_help` and `long_about`).

This patch *doesn't* contain the additional feature I requested in [this comment](https://github.com/TeXitoi/structopt/issues/134#issuecomment-429464231). It would be easy to add it but I assume as long as it isn't clearly defined how to switch between the two behaviors it should not be introduced.