### PR TITLE
Fix invalid structopt syntax error message

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -155,7 +155,7 @@ impl Attrs {
                 match quote!(#path).to_string().as_ref() {
                     "structopt" => Some(
                         attr.interpret_meta()
-                            .expect(&format!("invalid structopt syntax: {}", quote!(attr))),
+                            .expect(&format!("invalid structopt syntax: {}", quote!(#attr))),
                     ),
                     _ => None,
                 }


### PR DESCRIPTION
There was a typo preventing the probematic attr to be shown to the user.