### PR TITLE
Remove line-ending periods from short help.

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -338,10 +338,14 @@ impl Attrs {
                 args: quote!(#merged_lines),
             });
 
+            // Remove trailing whitespace and period from short help, as rustdoc
+            // best practice is to use complete sentences, but command-line help
+            // typically omits the trailing period.
             let short_arg = doc_comments
                 .first()
                 .map(String::as_ref)
                 .map(str::trim)
+                .map(|s| s.trim_right_matches('.'))
                 .unwrap_or("");
 
             self.methods.push(Method {

--- a/tests/doc-comments-help.rs
+++ b/tests/doc-comments-help.rs
@@ -77,7 +77,7 @@ fn splits_flag_doc_comment_between_short_and_long() {
     #[derive(StructOpt, PartialEq, Debug)]
     #[structopt(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
-        /// DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES
+        /// DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES.
         ///
         /// Or something else
         #[structopt(long = "foo")]
@@ -100,6 +100,9 @@ fn splits_flag_doc_comment_between_short_and_long() {
         String::from_utf8(buffer).unwrap()
     };
 
+
+    assert!(short_help.contains("CIRCUMSTANCES"));
+    assert!(!short_help.contains("CIRCUMSTANCES."));
     assert!(!short_help.contains("Or something else"));
     assert!(long_help.contains("DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES"));
     assert!(long_help.contains("Or something else"));

--- a/tests/doc-comments-help.rs
+++ b/tests/doc-comments-help.rs
@@ -100,7 +100,6 @@ fn splits_flag_doc_comment_between_short_and_long() {
         String::from_utf8(buffer).unwrap()
     };
 
-
     assert!(short_help.contains("CIRCUMSTANCES"));
     assert!(!short_help.contains("CIRCUMSTANCES."));
     assert!(!short_help.contains("Or something else"));


### PR DESCRIPTION
This makes the generated short help more natural for the command-line,
while allowing the rustdoc text to have the period that's standard for
rustdoc comments.