### PR TITLE
Suppress `clippy::redundant_closure`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: rust
 cache: cargo
-rust:
-  - 1.21.0
-  - stable
-  - beta
-  - nightly
 matrix:
   include:
+    - rust: 1.21.0
+      # `examples/enum_in_args.rs` cannot be compiled because of `clap::arg_enum!`.
+      env: TARGETS=--tests
+    - rust: stable
+    - rust: beta
+    - rust: nightly
     - rust: nightly
       env: FEATURES="--features nightly"
     - rust: stable
@@ -14,4 +15,4 @@ matrix:
       before_script: rustup component add rustfmt-preview
       script: cargo fmt --all -- --check
 script:
-  - cargo test $FEATURES
+  - cargo test $FEATURES $TARGETS

--- a/examples/enum_in_args.rs
+++ b/examples/enum_in_args.rs
@@ -1,8 +1,10 @@
-#[macro_use]
-extern crate structopt;
-#[macro_use]
-extern crate clap;
+//! current `clap::arg_enum!` uses "non-ident macro path" feature, which was stabilized in
+//! Rust 1.31.0.
 
+extern crate clap;
+extern crate structopt;
+
+use clap::arg_enum;
 use structopt::StructOpt;
 
 arg_enum! {


### PR DESCRIPTION
Fixes #177. We cannot change `.map_err(|e| e.to_string())` to `.map_err(ToString::to_string)` since `e` is not a reference in most cases. Instead, we have to wirte

- `.map_err(|e| (&e).to_string())`
or
- `.map_err(|e| ::std::string::ToString::to_string(&e))`

to suppress the warning.

The upstream clippy has already stopped triggering the warning for macros. This hack will be obsolete, but the current stable clippy will keep producing the warning until Rust 1.35 is released.
rust-lang/rust-clippy/pull/3816