### PR TITLE
Fix some clippy lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: cargo
 matrix:
   include:
-    - rust: 1.21.0
+    - rust: 1.31.0
       # `examples/enum_in_args.rs` cannot be compiled because of `clap::arg_enum!`.
       env: TARGETS=--tests
     - rust: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.2.16 (2019-04-24)
+
+* 1.31.0 is the minimum required rustc version by
+  [@owenthewizard](https://github.com/owenthewizard)
+
 # v0.2.15 (2018-03-08)
 
 * Fix [#168](https://github.com/TeXitoi/structopt/issues/168) by [@TeXitoi](https://github.com/TeXitoi)

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -114,10 +114,10 @@ impl ::std::str::FromStr for CasingStyle {
 }
 
 impl Attrs {
-    fn new(name: String, casing: CasingStyle) -> Attrs {
+    fn new(name: String, casing: CasingStyle) -> Self {
         let cased_name = casing.translate(&name);
 
-        Attrs {
+        Self {
             name,
             cased_name,
             casing,
@@ -215,9 +215,8 @@ impl Attrs {
                             use Parser::*;
                             let parser = i.to_string().parse().unwrap();
                             let function = match parser {
-                                FromStr => quote!(::std::convert::From::from),
+                                FromStr | FromOsStr=> quote!(::std::convert::From::from),
                                 TryFromStr => quote!(::std::str::FromStr::from_str),
-                                FromOsStr => quote!(::std::convert::From::from),
                                 TryFromOsStr => panic!(
                                     "cannot omit parser function name with `try_from_os_str`"
                                 ),
@@ -348,8 +347,7 @@ impl Attrs {
                 .first()
                 .map(String::as_ref)
                 .map(str::trim)
-                .map(|s| s.trim_right_matches('.'))
-                .unwrap_or("");
+                .map_or("", |s| s.trim_right_matches('.'));
 
             self.methods.push(Method {
                 name: name.to_string(),
@@ -362,7 +360,7 @@ impl Attrs {
             });
         }
     }
-    pub fn from_struct(attrs: &[Attribute], name: String, argument_casing: CasingStyle) -> Attrs {
+    pub fn from_struct(attrs: &[Attribute], name: String, argument_casing: CasingStyle) -> Self {
         let mut res = Self::new(name, argument_casing);
         let attrs_with_env = [
             ("version", "CARGO_PKG_VERSION"),
@@ -408,7 +406,7 @@ impl Attrs {
             Ty::Other
         }
     }
-    pub fn from_field(field: &syn::Field, struct_casing: CasingStyle) -> Attrs {
+    pub fn from_field(field: &syn::Field, struct_casing: CasingStyle) -> Self {
         let name = field.ident.as_ref().unwrap().to_string();
         let mut res = Self::new(name, struct_casing);
         res.push_doc_comment(&field.attrs, "help");
@@ -477,7 +475,7 @@ impl Attrs {
     }
     pub fn methods(&self) -> TokenStream {
         let methods = self.methods.iter().map(|&Method { ref name, ref args }| {
-            let name = Ident::new(&name, Span::call_site());
+            let name = Ident::new(name, Span::call_site());
             quote!( .#name(#args) )
         });
         quote!( #(#methods)* )
@@ -485,13 +483,13 @@ impl Attrs {
     pub fn cased_name(&self) -> &str {
         &self.cased_name
     }
-    pub fn parser(&self) -> &(Parser, TokenStream) {
+    pub const fn parser(&self) -> &(Parser, TokenStream) {
         &self.parser
     }
-    pub fn kind(&self) -> Kind {
+    pub const fn kind(&self) -> Kind {
         self.kind
     }
-    pub fn casing(&self) -> CasingStyle {
+    pub const fn casing(&self) -> CasingStyle {
         self.casing
     }
 }

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -215,7 +215,7 @@ impl Attrs {
                             use Parser::*;
                             let parser = i.to_string().parse().unwrap();
                             let function = match parser {
-                                FromStr | FromOsStr=> quote!(::std::convert::From::from),
+                                FromStr | FromOsStr => quote!(::std::convert::From::from),
                                 TryFromStr => quote!(::std::str::FromStr::from_str),
                                 TryFromOsStr => panic!(
                                     "cannot omit parser function name with `try_from_os_str`"

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! This crate is custom derive for StructOpt. It should not be used
+//! This crate is custom derive for `StructOpt`. It should not be used
 //! directly. See [structopt documentation](https://docs.rs/structopt)
 //! for the usage of `#[derive(StructOpt)]`.
 
@@ -28,7 +28,7 @@ use syn::*;
 /// Default casing style for generated arguments.
 const DEFAULT_CASING: CasingStyle = CasingStyle::Verbatim;
 
-/// Output for the gen_xxx() methods were we need more than a simple stream of tokens.
+/// Output for the `gen_xxx()` methods were we need more than a simple stream of tokens.
 ///
 /// The output of a generation method is not only the stream of new tokens but also the attribute
 /// information of the current element. These attribute information may contain valuable information
@@ -80,7 +80,7 @@ fn gen_augmentation(
     let subcmds: Vec<_> = fields
         .iter()
         .filter_map(|field| {
-            let attrs = Attrs::from_field(&field, parent_attribute.casing());
+            let attrs = Attrs::from_field(field, parent_attribute.casing());
             if let Kind::Subcommand(ty) = attrs.kind() {
                 let subcmd_type = match (ty, sub_type(&field.ty)) {
                     (Ty::Option, Some(sub_type)) => sub_type,


### PR DESCRIPTION
Some interesting ones I wasn't able to grok and/or fix:

```
warning: called `filter_map(p).flat_map(q)` on an `Iterator`. This is more succinctly expressed by calling `.flat_map(..)` and filtering by returning an empty Iterator.
   --> structopt-derive/src/attrs.rs:152:13
    |
152 | /             attrs
153 | |                 .iter()
154 | |                 .filter_map(|attr| {
155 | |                     let path = &attr.path;
...   |
165 | |                     tokens => panic!("unsupported syntax: {}", quote!(#tokens).to_string()),
166 | |                 })
    | |__________________^
    |
    = note: `-W clippy::filter-map` implied by `-W clippy::pedantic`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#filter_map
```

and

```
warning: you seem to be trying to use match for destructuring a single pattern. Consider using `if let`
   --> structopt-derive/src/lib.rs:199:33
    |
199 |                   let unwrapper = match ty {
    |  _________________________________^
200 | |                     Ty::Option => quote!(),
201 | |                     _ => quote!( .unwrap() ),
202 | |                 };
    | |_________________^ help: try this: `if let Ty::Option = ty { quote!() } else { quote!( .unwrap() ) }`
    |
    = note: `-W clippy::single-match-else` implied by `-W clippy::pedantic`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match_else
```

It'd be nice to fix those too.