### PR TITLE
Update deprecated trim_{left,right}_matches functions

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -298,11 +298,11 @@ impl Attrs {
                     }
                     let value = s.value();
                     let text = value
-                        .trim_left_matches("//!")
-                        .trim_left_matches("///")
-                        .trim_left_matches("/*!")
-                        .trim_left_matches("/**")
-                        .trim_right_matches("*/")
+                        .trim_start_matches("//!")
+                        .trim_start_matches("///")
+                        .trim_start_matches("/*!")
+                        .trim_start_matches("/**")
+                        .trim_end_matches("*/")
                         .trim();
                     if text.is_empty() {
                         Some("\n\n".to_string())
@@ -348,7 +348,7 @@ impl Attrs {
                 .first()
                 .map(String::as_ref)
                 .map(str::trim)
-                .map(|s| s.trim_right_matches('.'))
+                .map(|s| s.trim_end_matches('.'))
                 .unwrap_or("");
 
             self.methods.push(Method {


### PR DESCRIPTION
Those functions were deprecated in Rust 1.33.0, so I just decided to get rid of the warning messages.