### PR TITLE
Support Option<Option<T>> field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Support `Option<Option<T>>` type for fields by [@sphynx](https://github.com/sphynx)
+  ([#188](https://github.com/TeXitoi/structopt/issues/188))
+
 # v0.2.15 (2018-03-08)
 
 * Fix [#168](https://github.com/TeXitoi/structopt/issues/168) by [@TeXitoi](https://github.com/TeXitoi)

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -30,6 +30,17 @@ struct Opt {
     /// command line.
     #[structopt(help = "Output file, stdout if not present")]
     output: Option<String>,
+
+    /// An optional parameter with optional value, will be `None` if
+    /// not present on the command line, will be `Some(None)` if no
+    /// argument is provided (i.e. `--log`) and will be
+    /// `Some(Some(String))` if argument is provided (e.g. `--log
+    /// log.txt`).
+    #[structopt(
+        long = "log",
+        help = "Log file, stdout if no file, no logging if not present"
+    )]
+    log: Option<Option<String>>,
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,12 +104,13 @@
 //!
 //! The type of the field gives the kind of argument:
 //!
-//! Type                 | Effect                                            | Added method call to `clap::Arg`
-//! ---------------------|---------------------------------------------------|--------------------------------------
-//! `bool`               | `true` if the flag is present                     | `.takes_value(false).multiple(false)`
-//! `Option<T: FromStr>` | optional positional argument or option            | `.takes_value(true).multiple(false)`
-//! `Vec<T: FromStr>`    | list of options or the other positional arguments | `.takes_value(true).multiple(true)`
-//! `T: FromStr`         | required option or positional argument            | `.takes_value(true).multiple(false).required(!has_default)`
+//! Type                         | Effect                                            | Added method call to `clap::Arg`
+//! -----------------------------|---------------------------------------------------|--------------------------------------
+//! `bool`                       | `true` if the flag is present                     | `.takes_value(false).multiple(false)`
+//! `Option<T: FromStr>`         | optional positional argument or option            | `.takes_value(true).multiple(false)`
+//! `Option<Option<T: FromStr>>` | optional option with optional value               | `.takes_value(true).multiple(false).min_values(0).max_values(1)`
+//! `Vec<T: FromStr>`            | list of options or the other positional arguments | `.takes_value(true).multiple(true)`
+//! `T: FromStr`                 | required option or positional argument            | `.takes_value(true).multiple(false).required(!has_default)`
 //!
 //! The `FromStr` trait is used to convert the argument to the given
 //! type, and the `Arg::validator` method is set to a method using

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -404,12 +404,9 @@ impl Attrs {
         {
             match segments.iter().last().unwrap().ident.to_string().as_str() {
                 "bool" => Ty::Bool,
-                "Option" => match sub_type(ty) {
-                    Some(t) => match Attrs::ty_from_field(t) {
-                        Ty::Option => Ty::OptionOption,
-                        _ => Ty::Option,
-                    },
-                    None => Ty::Option,
+                "Option" => match sub_type(ty).map(Attrs::ty_from_field) {
+                    Some(Ty::Option) => Ty::OptionOption,
+                    _ => Ty::Option,
                 },
                 "Vec" => Ty::Vec,
                 _ => Ty::Other,

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -10,7 +10,10 @@ use heck::{CamelCase, KebabCase, MixedCase, ShoutySnakeCase, SnakeCase};
 use proc_macro2::{Span, TokenStream};
 use std::{env, mem};
 use syn::Type::Path;
-use syn::{self, Attribute, Ident, LitStr, MetaList, MetaNameValue, TypePath};
+use syn::{
+    self, AngleBracketedGenericArguments, Attribute, GenericArgument, Ident, LitStr, MetaList,
+    MetaNameValue, PathArguments, PathSegment, TypePath,
+};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Kind {
@@ -23,6 +26,7 @@ pub enum Ty {
     Bool,
     Vec,
     Option,
+    OptionOption,
     Other,
 }
 #[derive(Debug)]
@@ -400,7 +404,13 @@ impl Attrs {
         {
             match segments.iter().last().unwrap().ident.to_string().as_str() {
                 "bool" => Ty::Bool,
-                "Option" => Ty::Option,
+                "Option" => match sub_type(ty) {
+                    Some(t) => match Attrs::ty_from_field(t) {
+                        Ty::Option => Ty::OptionOption,
+                        _ => Ty::Option,
+                    },
+                    None => Ty::Option,
+                },
                 "Vec" => Ty::Vec,
                 _ => Ty::Other,
             }
@@ -430,7 +440,11 @@ impl Attrs {
                 if !res.methods.iter().all(|m| m.name == "help") {
                     panic!("methods in attributes is not allowed for subcommand");
                 }
-                res.kind = Kind::Subcommand(Self::ty_from_field(&field.ty));
+                let ty = Self::ty_from_field(&field.ty);
+                if ty == Ty::OptionOption {
+                    panic!("Option<Option<T>> type is not allowed for subcommand")
+                }
+                res.kind = Kind::Subcommand(ty);
             }
             Kind::Arg(_) => {
                 let mut ty = Self::ty_from_field(&field.ty);
@@ -455,6 +469,12 @@ impl Attrs {
                         }
                         if res.has_method("required") {
                             panic!("required is meaningless for Option")
+                        }
+                    }
+                    Ty::OptionOption => {
+                        // If it's a positional argument.
+                        if !(res.has_method("long") || res.has_method("short")) {
+                            panic!("Option<Option<T>> type is meaningless for positional argument")
                         }
                     }
                     _ => (),
@@ -493,5 +513,29 @@ impl Attrs {
     }
     pub fn casing(&self) -> CasingStyle {
         self.casing
+    }
+}
+
+pub fn sub_type(t: &syn::Type) -> Option<&syn::Type> {
+    let segs = match *t {
+        syn::Type::Path(TypePath {
+            path: syn::Path { ref segments, .. },
+            ..
+        }) => segments,
+        _ => return None,
+    };
+    match *segs.iter().last().unwrap() {
+        PathSegment {
+            arguments:
+                PathArguments::AngleBracketed(AngleBracketedGenericArguments { ref args, .. }),
+            ..
+        } if args.len() == 1 => {
+            if let GenericArgument::Type(ref ty) = args[0] {
+                Some(ty)
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -19,7 +19,7 @@ extern crate proc_macro2;
 
 mod attrs;
 
-use attrs::{Attrs, CasingStyle, Kind, Parser, Ty, sub_type};
+use attrs::{sub_type, Attrs, CasingStyle, Kind, Parser, Ty};
 use proc_macro2::{Span, TokenStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -151,3 +151,63 @@ fn option_from_str() {
     assert_eq!(Opt { a: None }, Opt::from_iter(&["test"]));
     assert_eq!(Opt { a: Some(A) }, Opt::from_iter(&["test", "foo"]));
 }
+
+#[test]
+fn optional_argument_for_optional_option() {
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(short = "a")]
+        arg: Option<Option<i32>>,
+    }
+    assert_eq!(
+        Opt { arg: Some(Some(42)) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42"]))
+    );
+    assert_eq!(
+        Opt { arg: Some(None) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a"]))
+    );
+    assert_eq!(
+        Opt { arg: None },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test"]))
+    );
+    assert!(Opt::clap()
+        .get_matches_from_safe(&["test", "-a42", "-a24"])
+        .is_err());
+}
+
+#[test]
+fn two_option_options() {
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(short = "a")]
+        arg: Option<Option<i32>>,
+
+        #[structopt(long = "field")]
+        field: Option<Option<String>>,
+    }
+    assert_eq!(
+        Opt { arg: Some(Some(42)), field: Some(Some("f".into())) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42", "--field", "f"]))
+    );
+    assert_eq!(
+        Opt { arg: Some(Some(42)), field: Some(None) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42", "--field"]))
+    );
+    assert_eq!(
+        Opt { arg: Some(None), field: Some(None) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a", "--field"]))
+    );
+    assert_eq!(
+        Opt { arg: Some(None), field: Some(Some("f".into())) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a", "--field", "f"]))
+    );
+    assert_eq!(
+        Opt { arg: None, field: Some(None) },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "--field"]))
+    );
+    assert_eq!(
+        Opt { arg: None, field: None },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test"]))
+    );
+}

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -160,7 +160,9 @@ fn optional_argument_for_optional_option() {
         arg: Option<Option<i32>>,
     }
     assert_eq!(
-        Opt { arg: Some(Some(42)) },
+        Opt {
+            arg: Some(Some(42))
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42"]))
     );
     assert_eq!(
@@ -187,27 +189,45 @@ fn two_option_options() {
         field: Option<Option<String>>,
     }
     assert_eq!(
-        Opt { arg: Some(Some(42)), field: Some(Some("f".into())) },
+        Opt {
+            arg: Some(Some(42)),
+            field: Some(Some("f".into()))
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42", "--field", "f"]))
     );
     assert_eq!(
-        Opt { arg: Some(Some(42)), field: Some(None) },
+        Opt {
+            arg: Some(Some(42)),
+            field: Some(None)
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a42", "--field"]))
     );
     assert_eq!(
-        Opt { arg: Some(None), field: Some(None) },
+        Opt {
+            arg: Some(None),
+            field: Some(None)
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a", "--field"]))
     );
     assert_eq!(
-        Opt { arg: Some(None), field: Some(Some("f".into())) },
+        Opt {
+            arg: Some(None),
+            field: Some(Some("f".into()))
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "-a", "--field", "f"]))
     );
     assert_eq!(
-        Opt { arg: None, field: Some(None) },
+        Opt {
+            arg: None,
+            field: Some(None)
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "--field"]))
     );
     assert_eq!(
-        Opt { arg: None, field: None },
+        Opt {
+            arg: None,
+            field: None
+        },
         Opt::from_clap(&Opt::clap().get_matches_from(&["test"]))
     );
 }


### PR DESCRIPTION
Closes #188 

I used `sub_type` function in `Attrs` module, so I moved it to there and exported so that it can be reused in `lib.rs`, I am not sure this is an optimal solution, please let me know if you want to change that (for example to have a separate module for types manipulations or anything else).

Another thing that I wanted to add to tests: is to make sure that `Option<Option<T>>` cannot be used for positional arguments. In this case I would expect a macro code-generation to fail, but I'm not sure how to make a test which expects particular macro failure. For now, I just checked that it works manually.

Also please note that I am using `max_values=1` as well as `min_values=0` to limit number of values to 1 in the generated `clap` code. However, handling of `max_option` in `clap` apparently has a bug: it tries to consume one more argument than it should during the parsing. 

I fixed that bug and prepared a PR here: https://github.com/clap-rs/clap/pull/1481  
However, before that bug is fixed, theoretically we can have problems if, say, `Option<Option<T>>` long field with a value is immediately followed by a subcommand, like this:

```
test --field 1 add -p 2
```

then `clap` (without my fix) would continue consuming arguments for `--field` even when `max_values=1` is set, so it will consume subcommand `add` as well and parsing will fail on seeing `-p`. But this is not directly related to `Option<Option<T>>` feature, just something to keep mind since it's related to `max_values`.

Please let me know if you have any suggestions about the code.

 