### PR TITLE
Optionally add paw support for structopt as a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add optional feature to support `paw` by [@gameldar](https://github.com/gameldar)
+  ([#187](https://github.com/TeXitoi/structopt/issues/187))
 * Support optional vectors of arguments for distinguishing between `-o 1 2`, `-o` and no option provided at all
   by [@sphynx](https://github.com/sphynx)
   ([#180](https://github.com/TeXitoi/structopt/issues/188))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lints = ["clap/lints"]
 debug = ["clap/debug"]
 no_cargo = ["clap/no_cargo"]
 doc = ["clap/doc"]
+paw = ["structopt-derive/paw"]
 
 [badges]
 travis-ci = { repository = "TeXitoi/structopt" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,18 @@
 //! structopt = { version = "0.2", default-features = false }
 //! ```
 //!
+//!
+//! Support for [`paw`](https://github.com/rust-cli/paw) (the
+//! `Command line argument paw-rser abstraction for main`) is disabled
+//! by default, but can be enabled in the `structopt` dependency
+//! with the feature `paw`:
+//!
+//! ```toml
+//! [dependencies]
+//! structopt = { version = "0.2", features = [ "paw" ] }
+//! paw = "1.0"
+//! ```
+//!
 //! ## How to `derive(StructOpt)`
 //!
 //! First, let's look at an example:

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -20,6 +20,7 @@ heck = "^0.3.0"
 
 [features]
 nightly = ["proc-macro2/nightly"]
+paw = []
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Create an optional feature that when turned on add in the required paw:ParseArgs trait implementation that allows use of StructOpt as the argument for the fn main.