### PR TITLE
Update deprecated function and provide more info about the parsing error

### DIFF
--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0/MIT"
 travis-ci = { repository = "TeXitoi/structopt" }
 
 [dependencies]
-syn = "0.15"
+syn = "0.15.10"
 quote = "0.6"
 proc-macro2 = "0.4"
 heck = "^0.3.0"

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -153,26 +153,25 @@ impl Attrs {
         use Meta::*;
         use NestedMeta::*;
 
-        let structopt_attrs =
-            attrs
-                .iter()
-                .filter_map(|attr| {
-                    let path = &attr.path;
-                    match quote!(#path).to_string().as_ref() {
-                        "structopt" => Some(attr.interpret_meta().unwrap_or_else(|| {
-                            panic!("invalid structopt syntax: {}", quote!(#attr))
-                        })),
-                        _ => None,
-                    }
-                })
-                .flat_map(|m| match m {
-                    List(l) => l.nested,
-                    tokens => panic!("unsupported syntax: {}", quote!(#tokens).to_string()),
-                })
-                .map(|m| match m {
-                    Meta(m) => m,
-                    ref tokens => panic!("unsupported syntax: {}", quote!(#tokens).to_string()),
-                });
+        let structopt_attrs = attrs
+            .iter()
+            .filter_map(|attr| {
+                let path = &attr.path;
+                match quote!(#path).to_string().as_ref() {
+                    "structopt" => Some(attr.parse_meta().unwrap_or_else(|e| {
+                        panic!("invalid structopt syntax: {}: {}", e, quote!(#attr))
+                    })),
+                    _ => None,
+                }
+            })
+            .flat_map(|m| match m {
+                List(l) => l.nested,
+                tokens => panic!("unsupported syntax: {}", quote!(#tokens).to_string()),
+            })
+            .map(|m| match m {
+                Meta(m) => m,
+                ref tokens => panic!("unsupported syntax: {}", quote!(#tokens).to_string()),
+            });
 
         for attr in structopt_attrs {
             match attr {


### PR DESCRIPTION
Update deprecated `interpret_meta` function from `syn`, as mentioned in https://github.com/TeXitoi/structopt/issues/178#issuecomment-497946337