### PR TITLE
Explicitly specify the Result type

### DIFF
--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -437,7 +437,7 @@ fn gen_paw_impl(name: &Ident) -> TokenStream {
         impl paw::ParseArgs for #name {
             type Error = std::io::Error;
 
-            fn parse_args() -> Result<Self, Self::Error> {
+            fn parse_args() -> std::result::Result<Self, Self::Error> {
                 Ok(<#name as ::structopt::StructOpt>::from_args())
             }
         }


### PR DESCRIPTION
The name `Result` is evaluated in the user context, which may break when another `Result` type is used. For example, in the presence of [the basic error-chain quickstart](https://github.com/rust-lang-nursery/error-chain/blob/master/examples/quickstart.rs), this leads to:
```
   Compiling application v0.0.1 (/home/ghast/rust-cli-template)
error[E0107]: wrong number of type arguments: expected 1, found 2
  --> src/main.rs:13:10
   |
13 | #[derive(structopt::StructOpt, Debug)]
   |          ^^^^^^^^^^^^^^^^^^^^ unexpected type argument

error: aborting due to previous error

For more information about this error, try `rustc --explain E0107`.
error: Could not compile `application`.
```

By explicitly specifying the `Result` type, this name clash can be resolved correctly.