### PR TITLE
Fix clippy warnings

### DIFF
--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -290,8 +290,7 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>, parent_attribute: &Attrs) 
                     Ty::OptionVec => quote_spanned! { ty.span()=>
                         if matches.is_present(#name) {
                             Some(matches.#values_of(#name)
-                                 .map(|v| v.map(#parse).collect())
-                                 .unwrap_or_else(Vec::new))
+                                 .map_or_else(Vec::new, |v| v.map(#parse).collect()))
                         } else {
                             None
                         }
@@ -299,8 +298,7 @@ fn gen_constructor(fields: &Punctuated<Field, Comma>, parent_attribute: &Attrs) 
 
                     Ty::Vec => quote_spanned! { ty.span()=>
                         matches.#values_of(#name)
-                            .map(|v| v.map(#parse).collect())
-                            .unwrap_or_else(Vec::new)
+                            .map_or_else(Vec::new, |v| v.map(#parse).collect())
                     },
 
                     Ty::Other if occurrences => quote_spanned! { ty.span()=>


### PR DESCRIPTION
Even after #263 I'm still getting some warnings.
```
warning: called `map(f).unwrap_or_else(g)` on an Option value. This can be done more directly by calling `map_or_else(g, f)` instead
   --> src\main.rs:167:15
    |
167 |         urls: Vec<String>,
    |               ^^^
    |
    = note: replace `map(Vec).unwrap_or_else(Vec)` with `map_or_else(Vec, Vec)`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_map_unwrap_or_else
```
I think this one is probably just worth fixing?
Tests all pass still, of course, since this doesn't change any behavior at all.