### PR TITLE
docs: observes that the trait is more than from_args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,11 @@
 //! (unless they're [subcommands](#subcommands)),
 //! and you can adjust these apps and args by `#[structopt(...)]` [attributes](#attributes).
 //!
+//! The derived `StructOpt` trait allows access to other methods besides
+//! `from_args`. You can, for instance, get the underlying `clap::ArgMatches`
+//! by doing `Opt::clap().get_matches()`. See the [trait's reference documentation](trait.StructOpt.html)
+//! for more details.
+//!
 //! ## Attributes
 //!
 //! `#[structopt(...)]` attributes fall into two categories:


### PR DESCRIPTION
Fixes #107 

Simply adds an observation to the docs stating that the `StructOpt` trait is more than `from_args`.

Please feel free to point any mistakes. Especially in my English, since it isn't my first language.