### PR TITLE
Fix parse for OptionVec ref pull #191

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -508,7 +508,7 @@ impl Attrs {
                 let mut ty = Self::ty_from_field(&field.ty);
                 if res.has_custom_parser {
                     match *ty {
-                        Ty::Option | Ty::Vec => (),
+                        Ty::Option | Ty::Vec | Ty::OptionVec => (),
                         _ => ty = Sp::new(Ty::Other, ty.span()),
                     }
                 }


### PR DESCRIPTION
Old implementation will forbid parse for Option<Vec<T>> and the error message is not helpful.