### PR TITLE
Pass the try_from_str functions a &str instead of a &String.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Upcoming
+
+* `try_from_str` functions are now called with a `&str` instead of a `&String` ([#282](https://github.com/TeXitoi/structopt/pull/282))
+
 # v0.3.4 (2019-11-08)
 
 * `rename_all` does not apply to fields that were annotated with explicit

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -126,7 +126,7 @@ fn gen_augmentation(
                 let validator = match *parser.kind {
                     ParserKind::TryFromStr => quote_spanned! { func.span()=>
                         .validator(|s| {
-                            #func(&s)
+                            #func(s.as_str())
                             .map(|_: #convert_type| ())
                             .map_err(|e| e.to_string())
                         })

--- a/tests/custom-string-parsers.rs
+++ b/tests/custom-string-parsers.rs
@@ -8,7 +8,7 @@
 
 use structopt::StructOpt;
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::{CString, OsStr, OsString};
 use std::num::ParseIntError;
 use std::path::PathBuf;
 
@@ -289,4 +289,18 @@ fn test_custom_bool() {
         },
         Opt::from_iter(&["test", "-dtrue", "-bfalse", "-btrue", "-bfalse", "-bfalse"])
     );
+}
+
+#[test]
+fn test_cstring() {
+    #[derive(StructOpt)]
+    struct Opt {
+        #[structopt(parse(try_from_str = CString::new))]
+        c_string: CString,
+    }
+    assert!(Opt::clap().get_matches_from_safe(&["test"]).is_err());
+    assert_eq!(Opt::from_iter(&["test", "bla"]).c_string.to_bytes(), b"bla");
+    assert!(Opt::clap()
+        .get_matches_from_safe(&["test", "bla\0bla"])
+        .is_err());
 }


### PR DESCRIPTION
In most cases this doesn't matter, as &String is coerced to a &str, but
this fails for generic functions like CString::new.

The added test failed to compile before this change.