### PR TITLE
Handle special types correctly

### DIFF
--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -15,10 +15,12 @@ extern crate proc_macro;
 mod attrs;
 mod parse;
 mod spanned;
+mod ty;
 
 use crate::{
-    attrs::{sub_type, Attrs, CasingStyle, Kind, Name, ParserKind, Ty},
+    attrs::{Attrs, CasingStyle, Kind, Name, ParserKind},
     spanned::Sp,
+    ty::{sub_type, Ty},
 };
 
 use proc_macro2::{Span, TokenStream};

--- a/structopt-derive/src/ty.rs
+++ b/structopt-derive/src/ty.rs
@@ -1,0 +1,108 @@
+//! Special types handling
+
+use crate::spanned::Sp;
+
+use syn::{
+    spanned::Spanned, GenericArgument, Path, PathArguments, PathArguments::AngleBracketed,
+    PathSegment, Type, TypePath,
+};
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum Ty {
+    Bool,
+    Vec,
+    Option,
+    OptionOption,
+    OptionVec,
+    Other,
+}
+
+impl Ty {
+    pub fn from_syn_ty(ty: &syn::Type) -> Sp<Self> {
+        use Ty::*;
+        let t = |kind| Sp::new(kind, ty.span());
+
+        if is_simple_ty(ty, "bool") {
+            t(Bool)
+        } else if is_generic_ty(ty, "Vec") {
+            t(Vec)
+        } else if let Some(subty) = subty_if_name(ty, "Option") {
+            if is_generic_ty(subty, "Option") {
+                t(OptionOption)
+            } else if is_generic_ty(subty, "Vec") {
+                t(OptionVec)
+            } else {
+                t(Option)
+            }
+        } else {
+            t(Other)
+        }
+    }
+}
+
+pub fn sub_type(ty: &syn::Type) -> Option<&syn::Type> {
+    subty_if(ty, |_| true)
+}
+
+fn only_last_segment(ty: &syn::Type) -> Option<&PathSegment> {
+    match ty {
+        Type::Path(TypePath {
+            qself: None,
+            path:
+                Path {
+                    leading_colon: None,
+                    segments,
+                },
+        }) => only_one(segments.iter()),
+
+        _ => None,
+    }
+}
+
+fn subty_if<F>(ty: &syn::Type, f: F) -> Option<&syn::Type>
+where
+    F: FnOnce(&PathSegment) -> bool,
+{
+    only_last_segment(ty)
+        .filter(|segment| f(segment))
+        .and_then(|segment| {
+            if let AngleBracketed(args) = &segment.arguments {
+                only_one(args.args.iter()).and_then(|genneric| {
+                    if let GenericArgument::Type(ty) = genneric {
+                        Some(ty)
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+}
+
+fn subty_if_name<'a>(ty: &'a syn::Type, name: &str) -> Option<&'a syn::Type> {
+    subty_if(ty, |seg| seg.ident == name)
+}
+
+fn is_simple_ty(ty: &syn::Type, name: &str) -> bool {
+    only_last_segment(ty)
+        .map(|segment| {
+            if let PathArguments::None = segment.arguments {
+                segment.ident == name
+            } else {
+                false
+            }
+        })
+        .unwrap_or(false)
+}
+
+fn is_generic_ty(ty: &syn::Type, name: &str) -> bool {
+    subty_if_name(ty, name).is_some()
+}
+
+fn only_one<I, T>(mut iter: I) -> Option<T>
+where
+    I: Iterator<Item = T>,
+{
+    iter.next().filter(|_| iter.next().is_none())
+}

--- a/tests/special_types.rs
+++ b/tests/special_types.rs
@@ -1,0 +1,73 @@
+//! Checks that types like `::std::option::Option` are not special
+
+use structopt::StructOpt;
+
+#[rustversion::since(1.37)]
+#[test]
+fn special_types_bool() {
+    mod inner {
+        #[allow(non_camel_case_types)]
+        #[derive(PartialEq, Debug)]
+        pub struct bool(pub String);
+
+        impl std::str::FromStr for self::bool {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(self::bool(s.into()))
+            }
+        }
+    };
+
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        arg: inner::bool,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: inner::bool("success".into())
+        },
+        Opt::from_iter(&["test", "success"])
+    );
+}
+
+#[test]
+fn special_types_option() {
+    fn parser(s: &str) -> Option<String> {
+        Some(s.to_string())
+    }
+
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(parse(from_str = parser))]
+        arg: ::std::option::Option<String>,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: Some("success".into())
+        },
+        Opt::from_iter(&["test", "success"])
+    );
+}
+
+#[test]
+fn special_types_vec() {
+    fn parser(s: &str) -> Vec<String> {
+        vec![s.to_string()]
+    }
+
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(parse(from_str = parser))]
+        arg: ::std::vec::Vec<String>,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: vec!["success".into()]
+        },
+        Opt::from_iter(&["test", "success"])
+    );
+}


### PR DESCRIPTION
While thinking on #285 I suggested to use `::vec::Vec` instead of `Vec` to prevent special casing, but a simple test proved me wrong. In fact, **any path that ends with `Vec<T>` will be considered as `Vec<T>`** which is wrong. The same goes for `Option` and `bool`.

I believe this is a bug and it should be fixed. This PR handles paths correctly, checking not only the last segment but also verifying that the said segment is *the only one* segment present, no leading `::`.

Technically, this is a breaking change but I believe this is a bug and, furthermore, I really doubt someone out there has been relying on this behavior.