### PR TITLE
Add true boolean argument to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ And then, in your rust file:
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+/// Special type to be used for `true` and `false` parsing
+type Bool = bool;
+
 /// A basic example
 #[derive(StructOpt, Debug)]
 #[structopt(name = "basic")]
@@ -56,6 +59,11 @@ struct Opt {
     /// Files to process
     #[structopt(name = "FILE", parse(from_os_str))]
     files: Vec<PathBuf>,
+    
+    // A parameter which needs to be explicitly set to either `true` or `false`.
+    /// Enable frobnication?
+    #[structopt(short, long)]
+    frobnicate: Bool,
 }
 
 fn main() {
@@ -89,14 +97,15 @@ FLAGS:
     -v, --verbose    Verbose mode (-v, -vv, -vvv, etc.)
 
 OPTIONS:
-    -l, --level <level>...     admin_level to consider
-    -c, --nb-cars <nb-cars>    Number of cars
-    -o, --output <output>      Output file
-    -s, --speed <speed>        Set speed [default: 42]
+    -f, --frobnicate <frobnicate>    Enable frobnication?
+    -l, --level <level>...           admin_level to consider
+    -c, --nb-cars <nb-cars>          Number of cars
+    -o, --output <output>            Output file
+    -s, --speed <speed>              Set speed [default: 42]
 
 ARGS:
     <file>...    Files to process
-$ ./basic -o foo.txt
+$ ./basic -o foo.txt -f true
 Opt {
     debug: false,
     verbose: 0,
@@ -105,8 +114,9 @@ Opt {
     nb_cars: None,
     level: [],
     files: [],
+    frobnicate: true,
 }
-$ ./basic -o foo.txt -dvvvs 1337 -l alice -l bob --nb-cars 4 bar.txt baz.txt
+$ ./basic -o foo.txt -dvvvs 1337 -l alice -l bob --nb-cars 4 bar.txt baz.txt --frobnicate false
 Opt {
     debug: true,
     verbose: 3,
@@ -123,6 +133,7 @@ Opt {
         "bar.txt",
         "baz.txt",
     ],
+    frobnicate: false,
 }
 ```
 


### PR DESCRIPTION
Regular bool types are only flags and their parsed value represents whether they were present on the command line or absent. However it is very useful to have true boolean argument parsing  which can be combined with `Option` or default values.

Closes #212