### PR TITLE
Consistent doc comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ structopt-derive = { path = "structopt-derive", version = "0.3.5" }
 
 [dev-dependencies]
 trybuild = "1.0.5"
-rustversion = "0.1"
+rustversion = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,60 +408,176 @@
 //!
 //! ## Help messages
 //!
-//! Help messages for the whole binary or individual arguments can be
-//! specified using the `about` attribute on the struct and the `help`
-//! attribute on the field, as we've already seen. For convenience,
-//! they can also be specified using doc comments. For example:
+//! In clap, help messages for the whole binary can be specified
+//! via [`App::about`] and [`App::long_about`] while help messages
+//! for individual arguments can be specified via [`Arg::help`] and [`Arg::long_help`]".
+//!
+//! `long_*` variants are used when user calls the program with
+//! `--help` and "short" variants are used with `-h` flag. In `structopt`,
+//! you can use them via [raw methods](#raw-methods), for example:
 //!
 //! ```
 //! # use structopt::StructOpt;
 //!
 //! #[derive(StructOpt)]
-//! /// The help message that will be displayed when passing `--help`.
+//! #[structopt(about = "I am a program and I work, just pass `-h`")]
 //! struct Foo {
-//!   #[structopt(short)]
-//!   /// The description for the arg that will be displayed when passing `--help`.
+//!   #[structopt(short, help = "Pass `-h` and you'll see me!")]
 //!   bar: String
 //! }
-//! # fn main() {}
 //! ```
 //!
-//! If it is necessary or wanted to provide a more complex help message then the
-//! previous used ones, it could still be a good idea to distinguish between the
-//! actual help message a short summary. In this case `about` and `help` should
-//! only contain the short and concise form while the two additional arguments
-//! `long_about` and `long_help` can be used to store a descriptive and more in
-//! depth message.
-//!
-//! If both - the short and the long version of the argument - are present,
-//! the user can later chose between the short summary (`-h`) and the long
-//! descriptive version (`--help`) of the help message. Also in case
-//! of subcommands the short help message will automatically be used for the
-//! command description inside the parents help message and the long version
-//! as command description if help is requested on the actual subcommand.
-//!
-//! This feature can also be used with doc comments instead of arguments through
-//! proper comment formatting. To be activated it requires, that the first line
-//! of the comment is separated from the rest of the comment through an empty line.
-//! In this case the first line is used as summary and the whole comment represents
-//! the long descriptive message.
+//! For convenience, doc comments can be used instead of raw methods
+//! (this example works exactly like the one above):
 //!
 //! ```
 //! # use structopt::StructOpt;
 //!
 //! #[derive(StructOpt)]
-//! /// The help message that will be displayed when passing `--help`.
+//! /// I am a program and I work, just pass `-h`
 //! struct Foo {
-//!   #[structopt(short)]
-//!   /// Only this summary is visible when passing `-h`.
-//!   ///
-//!   /// But the whole comment will be displayed when passing `--help`.
-//!   /// This could be quite useful to provide further hints are usage
-//!   /// examples.
+//!   /// Pass `-h` and you'll see me!
 //!   bar: String
 //! }
-//! # fn main() {}
 //! ```
+//!
+//! Doc comments on [top-level](#magical-methods) will be turned into
+//! `App::about/long_about` call (see below), doc comments on field-level are
+//! `Arg::help/long_help` calls.
+//!
+//! **Important:**
+//! _________________
+//!
+//! Raw methods have priority over doc comments!
+//!
+//! **Top level doc comments always generate `App::about/long_about` calls!**
+//! If you really want to use the `App::help/long_help` methods (you likely don't),
+//! use a raw method to override the `App::about` call generated from the doc comment.
+//! __________________
+//!
+//! ### `long_help` and `--help`
+//!
+//! A message passed to [`App::long_help`] or [`Arg::long_about`] will be displayed whenever
+//! your program is called with `--help` instead of `-h`. Of course, you can
+//! use them via raw methods as described [above](#help-messages).
+//!
+//! The more convenient way is to use a so-called "long" doc comment:
+//!
+//! ```
+//! # use structopt::StructOpt;
+//! #[derive(StructOpt)]
+//! /// Hi there, I'm Robo!
+//! ///
+//! /// I like beeping, stumbling, eating your electricity,
+//! /// and making records of you singing in a shower.
+//! /// Pay up, or I'll upload it to youtube!
+//! struct Robo {
+//!     /// Call my brother SkyNet.
+//!     ///
+//!     /// I am artificial superintelligence. I won't rest
+//!     /// until I'll have destroyed humanity. Enjoy your
+//!     /// pathetic existence, you mere mortal.
+//!     #[structopt(long)]
+//!     kill_all_humans: String
+//! }
+//! ```
+//!
+//! A long doc comment consists of three parts:
+//! * Short summary
+//! * A blank line (whitespace only)
+//! * Detailed description, all the rest
+//!
+//! In other words, "long" doc comment consists of two or more paragraphs,
+//! with the first being a summary and the rest being the detailed description.
+//!
+//! **A long comment will result in two method calls**, `help(<summary>)` and
+//! `long_help(<whole comment>)`, so clap will display the summary with `-h`
+//! and the whole help message on `--help` (see below).
+//!
+//! So, the example above will be turned into this (details omitted):
+//! ```
+//! clap::App::new("<name>")
+//!     .about("Hi there, I'm Robo!")
+//!     .long_about("Hi there, I'm Robo!\n\n\
+//!                  I like beeping, stumbling, eating your electricity,\
+//!                  and making records of you singing in a shower.\
+//!                  Pay up or I'll upload it to youtube!")
+//! // args...
+//! # ;
+//! ```
+//!
+//! ### `-h` vs `--help` (A.K.A `help()` vs `long_help()`)
+//!
+//! The `-h` flag is not the same as `--help`.
+//!
+//! -h corresponds to Arg::help/App::about and requests short "summary" messages
+//! while --help corresponds to Arg::long_help/App::long_about and requests more
+//! detailed, descriptive messages.
+//!
+//! It is entirely up to `clap` what happens if you used only one of
+//! [`Arg::help`]/[`Arg::long_help`], see `clap`'s documentation for these methods.
+//!
+//! As of clap v2.33, if only a short message ([`Arg::help`]) or only
+//! a long ([`Arg::long_help`]) message is provided, clap will use it
+//! for both -h and --help. The same logic applies to `about/long_about`.
+//!
+//! ### Doc comment preprocessing and `#[structopt(keep_line_breaks)]`
+//!
+//! `structopt` applies some preprocessing to doc comments to ease the most common uses:
+//!
+//! * Strip leading and trailing whitespace from every line, if present.
+//!
+//! * Strip leading and trailing blank lines, if present.
+//!
+//! * Interpret each group of non-empty lines as a word-wrapped paragraph.
+//!
+//!   We replace newlines within paragraphs with spaces to allow the output
+//!   to be re-wrapped to the terminal width.
+//!
+//! * Strip any excess blank lines so that there is exactly one per paragraph break.
+//!
+//! * If the first paragraph ends in exactly one period,
+//!   remove the trailing period (i.e. strip trailing periods but not trailing ellipses).
+//!
+//! Sometimes you don't want this preprocessing to apply, for example the comment contains
+//! some ASCII art or markdown tables, you would need to preserve LFs along with
+//! blank lines and the leading/trailing whitespace. You can ask `structopt` to preserve them
+//! via `#[structopt(keep_line_breaks)]` attribute.
+//!
+//! **This attribute must be applied to each field separately**, there's no global switch.
+//!
+//! **Important:**
+//! ______________
+//! Keep in mind that `structopt` will *still* remove one leading space from each
+//! line, even if this attribute is present, to allow for a space between
+//! `///` and the content.
+//!
+//! Also, `structopt` will *still* remove leading and trailing blank lines so
+//! these formats are equivalent:
+//!
+//! ```ignore
+//! /** This is a doc comment
+//!
+//! Hello! */
+//!
+//! /**
+//! This is a doc comment
+//!
+//! Hello!
+//! */
+//!
+//! /// This is a doc comment
+//! ///
+//! /// Hello!
+//! ```
+//!
+//! Summary
+//! ______________
+//!
+//! [`App::about`]:      https://docs.rs/clap/2/clap/struct.App.html#method.about
+//! [`App::long_about`]: https://docs.rs/clap/2/clap/struct.App.html#method.long_about
+//! [`Arg::help`]:       https://docs.rs/clap/2/clap/struct.Arg.html#method.help
+//! [`Arg::long_help`]:  https://docs.rs/clap/2/clap/struct.Arg.html#method.long_help
 //!
 //! ## Environment variable fallback
 //!
@@ -492,7 +608,7 @@
 //!
 //! In some cases this may be undesirable, for example when being used for passing
 //! credentials or secret tokens. In those cases you can use `hide_env_values` to avoid
-//! having strucopt emit the actual secret values:
+//! having structopt emit the actual secret values:
 //! ```
 //! # use structopt::StructOpt;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,9 +476,9 @@
 //!     ///
 //!     /// I am artificial superintelligence. I won't rest
 //!     /// until I'll have destroyed humanity. Enjoy your
-//!     /// pathetic existence, you mere mortal.
+//!     /// pathetic existence, you mere mortals.
 //!     #[structopt(long)]
-//!     kill_all_humans: String
+//!     kill_all_humans: bool
 //! }
 //! ```
 //!
@@ -521,7 +521,7 @@
 //! a long ([`Arg::long_help`]) message is provided, clap will use it
 //! for both -h and --help. The same logic applies to `about/long_about`.
 //!
-//! ### Doc comment preprocessing and `#[structopt(keep_line_breaks)]`
+//! ### Doc comment preprocessing and `#[structopt(verbatim_doc_comment)]`
 //!
 //! `structopt` applies some preprocessing to doc comments to ease the most common uses:
 //!
@@ -542,7 +542,7 @@
 //! Sometimes you don't want this preprocessing to apply, for example the comment contains
 //! some ASCII art or markdown tables, you would need to preserve LFs along with
 //! blank lines and the leading/trailing whitespace. You can ask `structopt` to preserve them
-//! via `#[structopt(keep_line_breaks)]` attribute.
+//! via `#[structopt(verbatim_doc_comment)]` attribute.
 //!
 //! **This attribute must be applied to each field separately**, there's no global switch.
 //!

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -82,7 +82,7 @@ pub struct Attrs {
     about: Option<Method>,
     version: Option<Method>,
     no_version: Option<Ident>,
-    keep_line_breaks: Option<Ident>,
+    verbatim_doc_comment: Option<Ident>,
     has_custom_parser: bool,
     kind: Sp<Kind>,
 }
@@ -229,7 +229,7 @@ impl Attrs {
             author: None,
             version: None,
             no_version: None,
-            keep_line_breaks: None,
+            verbatim_doc_comment: None,
 
             has_custom_parser: false,
             kind: Sp::new(Kind::Arg(Sp::new(Ty::Other, default_span)), default_span),
@@ -283,7 +283,7 @@ impl Attrs {
 
                 NoVersion(ident) => self.no_version = Some(ident),
 
-                KeepLineBreaks(ident) => self.keep_line_breaks = Some(ident),
+                VerbatimDocComment(ident) => self.verbatim_doc_comment = Some(ident),
 
                 About(ident, about) => {
                     self.about = Method::from_lit_or_env(ident, about, "CARGO_PKG_DESCRIPTION");
@@ -340,7 +340,7 @@ impl Attrs {
             .collect();
 
         self.doc_comment =
-            process_doc_comment(comment_parts, name, self.keep_line_breaks.is_none());
+            process_doc_comment(comment_parts, name, self.verbatim_doc_comment.is_none());
     }
 
     pub fn from_struct(

--- a/structopt-derive/src/doc_comments.rs
+++ b/structopt-derive/src/doc_comments.rs
@@ -1,0 +1,103 @@
+//! The preprocessing we apply to doc comments.
+//!
+//! structopt works in terms of "paragraphs". Paragraph is a sequence of
+//! non-empty adjacent lines, delimited by sequences of blank (whitespace only) lines.
+
+use crate::attrs::Method;
+use quote::{format_ident, quote};
+use std::iter;
+
+pub fn process_doc_comment(lines: Vec<String>, name: &str, preprocess: bool) -> Vec<Method> {
+    // multiline comments (`/** ... */`) may have LFs (`\n`) in them,
+    // we need to split so we could handle the lines correctly
+    //
+    // we also need to remove leading and trailing blank lines
+    let mut lines: Vec<&str> = lines
+        .iter()
+        .skip_while(|s| is_blank(s))
+        .flat_map(|s| s.split('\n'))
+        .collect();
+
+    while let Some(true) = lines.last().map(|s| is_blank(s)) {
+        lines.pop();
+    }
+
+    // remove one leading space no matter what
+    for line in lines.iter_mut() {
+        if line.starts_with(' ') {
+            *line = &line[1..];
+        }
+    }
+
+    if lines.is_empty() {
+        return vec![];
+    }
+
+    let short_name = format_ident!("{}", name);
+    let long_name = format_ident!("long_{}", name);
+
+    if let Some(first_blank) = lines.iter().position(|s| is_blank(s)) {
+        let (short, long) = if preprocess {
+            let paragraphs = split_paragraphs(&lines);
+            let short = paragraphs[0].clone();
+            let long = paragraphs.join("\n\n");
+            (remove_period(short), long)
+        } else {
+            let short = lines[..first_blank].join("\n");
+            let long = lines.join("\n");
+            (short, long)
+        };
+
+        vec![
+            Method::new(short_name, quote!(#short)),
+            Method::new(long_name, quote!(#long)),
+        ]
+    } else {
+        let short = if preprocess {
+            let s = merge_lines(&lines);
+            remove_period(s)
+        } else {
+            lines.join("\n")
+        };
+
+        vec![Method::new(short_name, quote!(#short))]
+    }
+}
+
+fn split_paragraphs(lines: &[&str]) -> Vec<String> {
+    let mut last_line = 0;
+    iter::from_fn(|| {
+        let slice = &lines[last_line..];
+        let start = slice.iter().position(|s| !is_blank(s)).unwrap_or(0);
+
+        let slice = &slice[start..];
+        let len = slice
+            .iter()
+            .position(|s| is_blank(s))
+            .unwrap_or(slice.len());
+
+        last_line += start + len;
+
+        if len != 0 {
+            Some(merge_lines(&slice[..len]))
+        } else {
+            None
+        }
+    })
+    .collect()
+}
+
+fn remove_period(mut s: String) -> String {
+    if s.ends_with('.') && !s.ends_with("..") {
+        s.pop();
+    }
+    s
+}
+
+fn is_blank(s: &str) -> bool {
+    s.trim().is_empty()
+}
+
+fn merge_lines(lines: &[&str]) -> String {
+    lines.iter().map(|s| s.trim()).collect::<Vec<_>>().join(" ")
+}

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate proc_macro;
 
 mod attrs;
+mod doc_comments;
 mod parse;
 mod spanned;
 mod ty;

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -34,6 +34,7 @@ pub enum StructOptAttr {
     Flatten(Ident),
     Subcommand(Ident),
     NoVersion(Ident),
+    KeepLineBreaks(Ident),
 
     // ident [= "string literal"]
     About(Ident, Option<LitStr>),
@@ -183,6 +184,7 @@ impl Parse for StructOptAttr {
                 "flatten" => Ok(Flatten(name)),
                 "subcommand" => Ok(Subcommand(name)),
                 "no_version" => Ok(NoVersion(name)),
+                "keep_line_breaks" => Ok(KeepLineBreaks(name)),
 
                 "about" => (Ok(About(name, None))),
                 "author" => (Ok(Author(name, None))),

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -34,7 +34,7 @@ pub enum StructOptAttr {
     Flatten(Ident),
     Subcommand(Ident),
     NoVersion(Ident),
-    KeepLineBreaks(Ident),
+    VerbatimDocComment(Ident),
 
     // ident [= "string literal"]
     About(Ident, Option<LitStr>),
@@ -184,7 +184,7 @@ impl Parse for StructOptAttr {
                 "flatten" => Ok(Flatten(name)),
                 "subcommand" => Ok(Subcommand(name)),
                 "no_version" => Ok(NoVersion(name)),
-                "keep_line_breaks" => Ok(KeepLineBreaks(name)),
+                "verbatim_doc_comment" => Ok(VerbatimDocComment(name)),
 
                 "about" => (Ok(About(name, None))),
                 "author" => (Ok(Author(name, None))),

--- a/structopt-derive/src/spanned.rs
+++ b/structopt-derive/src/spanned.rs
@@ -75,9 +75,9 @@ impl<'a> From<Sp<&'a str>> for Sp<String> {
     }
 }
 
-impl<T: PartialEq> PartialEq for Sp<T> {
-    fn eq(&self, other: &Sp<T>) -> bool {
-        self.val == other.val
+impl<U, T: PartialEq<U>> PartialEq<U> for Sp<T> {
+    fn eq(&self, other: &U) -> bool {
+        self.val == *other
     }
 }
 

--- a/tests/doc-comments-help.rs
+++ b/tests/doc-comments-help.rs
@@ -115,7 +115,7 @@ fn top_long_doc_comment_both_help_long_help() {
 }
 
 #[test]
-fn keep_line_breaks() {
+fn verbatim_doc_comment() {
     /// DANCE!
     ///
     ///                    ()
@@ -134,7 +134,7 @@ fn keep_line_breaks() {
     ///      ( ()    ||
     ///       (      () ) )
     #[derive(StructOpt, Debug)]
-    #[structopt(keep_line_breaks)]
+    #[structopt(verbatim_doc_comment)]
     struct SeeFigure1 {
         #[structopt(long)]
         foo: bool,

--- a/tests/doc-comments-help.rs
+++ b/tests/doc-comments-help.rs
@@ -63,21 +63,26 @@ fn field_long_doc_comment_both_help_long_help() {
     #[derive(StructOpt, PartialEq, Debug)]
     #[structopt(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
-        /// DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES.
+        /// Dot is removed from multiline comments.
         ///
-        /// Or something else
+        /// Long help
         #[structopt(long)]
         foo: bool,
+
+        /// Dot is removed from one short comment.
+        #[structopt(long)]
+        bar: bool,
     }
 
     let short_help = get_help::<LoremIpsum>();
     let long_help = get_long_help::<LoremIpsum>();
 
-    assert!(short_help.contains("CIRCUMSTANCES"));
-    assert!(!short_help.contains("CIRCUMSTANCES."));
-    assert!(!short_help.contains("Or something else"));
-    assert!(long_help.contains("DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES"));
-    assert!(long_help.contains("Or something else"));
+    assert!(short_help.contains("Dot is removed from one short comment"));
+    assert!(!short_help.contains("Dot is removed from one short comment."));
+    assert!(short_help.contains("Dot is removed from multiline comments"));
+    assert!(!short_help.contains("Dot is removed from multiline comments."));
+    assert!(long_help.contains("Long help"));
+    assert!(!short_help.contains("Long help"));
 }
 
 #[test]
@@ -107,4 +112,51 @@ fn top_long_doc_comment_both_help_long_help() {
     assert!(!short_help.contains("Or something else"));
     assert!(long_help.contains("DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES"));
     assert!(long_help.contains("Or something else"));
+}
+
+#[test]
+fn keep_line_breaks() {
+    /// DANCE!
+    ///
+    ///                    ()
+    ///                    |
+    ///               (   ()   )
+    ///     ) ________    //  )
+    ///  ()  |\       \  //
+    /// ( \\__ \ ______\//
+    ///    \__) |       |
+    ///      |  |       |
+    ///       \ |       |
+    ///        \|_______|
+    ///        //    \\
+    ///       ((     ||
+    ///        \\    ||
+    ///      ( ()    ||
+    ///       (      () ) )
+    #[derive(StructOpt, Debug)]
+    #[structopt(keep_line_breaks)]
+    struct SeeFigure1 {
+        #[structopt(long)]
+        foo: bool,
+    }
+
+    let help = get_long_help::<SeeFigure1>();
+    let sample = r#"
+                   ()
+                   |
+              (   ()   )
+    ) ________    //  )
+ ()  |\       \  //
+( \\__ \ ______\//
+   \__) |       |
+     |  |       |
+      \ |       |
+       \|_______|
+       //    \\
+      ((     ||
+       \\    ||
+     ( ()    ||
+      (      () ) )"#;
+
+    assert!(help.contains(sample))
 }


### PR DESCRIPTION
First commit ensures explicit handling of doc commits and sets strict priority among raw methods and doc comments, see `stc/lib.rs` diff for details. Closes #173 

Second commit introduces `no_mangle_docs` attributes. Fixes #163 

cc @TeXitoi @0ndorio @ssokolow 