### PR TITLE
CI: build only PRs and pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: type != push OR branch = master
+
 language: rust
 matrix:
   include:


### PR DESCRIPTION
Currently, every PR send by me triggers two identical CI builds: a build for push and a build for PR.

This way we trigger a build only for PRs and pushes to master.

Just stumbled upon it while was surfing across some project :)