### PR TITLE
Issue 324

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1035,10 +1035,6 @@ pub trait StructOptInternal: StructOpt {
     {
         None
     }
-
-    fn augment_version<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
-        app
-    }
 }
 
 impl<T: StructOpt> StructOpt for Box<T> {
@@ -1065,10 +1061,5 @@ impl<T: StructOptInternal> StructOptInternal for Box<T> {
     #[doc(hidden)]
     fn augment_clap<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
         <T as StructOptInternal>::augment_clap(app)
-    }
-
-    #[doc(hidden)]
-    fn augment_version<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
-        <T as StructOptInternal>::augment_version(app)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,12 +213,12 @@
 //! }
 //! ```
 //!
-//! - `name`: `[name = "name"]`
-//!   - On top level: `App::new("name")`.
+//! - `name`: `[name = expr]`
+//!   - On top level: `App::new(expr)`.
 //!
 //!     The binary name displayed in help messages. Defaults to the crate name given by Cargo.
 //!
-//!   - On field-level: `Arg::with_name("name")`.
+//!   - On field-level: `Arg::with_name(expr)`.
 //!
 //!     The name for the argument the field stands for, this name appears in help messages.
 //!     Defaults to a name, deduced from a field, see also
@@ -1035,6 +1035,10 @@ pub trait StructOptInternal: StructOpt {
     {
         None
     }
+
+    fn augment_version<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
+        app
+    }
 }
 
 impl<T: StructOpt> StructOpt for Box<T> {
@@ -1061,5 +1065,10 @@ impl<T: StructOptInternal> StructOptInternal for Box<T> {
     #[doc(hidden)]
     fn augment_clap<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
         <T as StructOptInternal>::augment_clap(app)
+    }
+
+    #[doc(hidden)]
+    fn augment_version<'a, 'b>(app: clap::App<'a, 'b>) -> clap::App<'a, 'b> {
+        <T as StructOptInternal>::augment_version(app)
     }
 }

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -225,11 +225,12 @@ fn gen_augmentation(
     });
 
     let app_methods = parent_attribute.top_level_methods();
+    let version = parent_attribute.version();
     quote! {{
         let #app_var = #app_var#app_methods;
         #( #args )*
         #subcmd
-        #app_var
+        #app_var#version
     }}
 }
 
@@ -382,7 +383,7 @@ fn gen_clap(attrs: &[Attribute]) -> GenOutput {
     let attrs = Attrs::from_struct(
         Span::call_site(),
         attrs,
-        Name::Assigned(LitStr::new(&name, Span::call_site())),
+        Name::Assigned(quote!(#name)),
         None,
         Sp::call_site(DEFAULT_CASING),
         Sp::call_site(DEFAULT_ENV_CASING),
@@ -483,23 +484,23 @@ fn gen_augment_clap_enum(
 
         let name = attrs.cased_name();
         let from_attrs = attrs.top_level_methods();
-
+        let version = attrs.version();
         quote! {
             .subcommand({
                 let #app_var = ::structopt::clap::SubCommand::with_name(#name);
                 let #app_var = #arg_block;
-                #app_var#from_attrs
+                #app_var#from_attrs#version
             })
         }
     });
 
     let app_methods = parent_attribute.top_level_methods();
-
+    let version = parent_attribute.version();
     quote! {
         fn augment_clap<'a, 'b>(
             app: ::structopt::clap::App<'a, 'b>
         ) -> ::structopt::clap::App<'a, 'b> {
-            app #app_methods #( #subcommands )*
+            app #app_methods #( #subcommands )* #version
         }
     }
 }

--- a/structopt-derive/src/spanned.rs
+++ b/structopt-derive/src/spanned.rs
@@ -27,16 +27,6 @@ impl<T> Sp<T> {
     }
 }
 
-impl<T: ToString> Sp<T> {
-    pub fn as_ident(&self) -> Ident {
-        Ident::new(&self.to_string(), self.span)
-    }
-
-    pub fn as_lit(&self) -> LitStr {
-        LitStr::new(&self.to_string(), self.span)
-    }
-}
-
 impl<T> Deref for Sp<T> {
     type Target = T;
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,5 +1,9 @@
-// https://github.com/TeXitoi/structopt/issues/151
-// https://github.com/TeXitoi/structopt/issues/289
+// https://github.com/TeXitoi/structopt/issues/{NUMBER}
+
+mod utils;
+use utils::*;
+
+use structopt::StructOpt;
 
 #[test]
 fn issue_151() {
@@ -64,4 +68,26 @@ fn issue_289() {
     assert!(Args::clap()
         .get_matches_from_safe(&["test", "some", "test"])
         .is_ok());
+}
+
+#[test]
+fn issue_324() {
+    fn my_version() -> &'static str {
+        "MY_VERSION"
+    }
+
+    #[derive(StructOpt)]
+    #[structopt(version = my_version())]
+    struct Opt {
+        #[structopt(subcommand)]
+        cmd: Option<SubCommand>,
+    }
+
+    #[derive(StructOpt)]
+    enum SubCommand {
+        Start,
+    }
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("MY_VERSION"));
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -80,7 +80,7 @@ fn issue_324() {
     #[structopt(version = my_version())]
     struct Opt {
         #[structopt(subcommand)]
-        cmd: Option<SubCommand>,
+        _cmd: Option<SubCommand>,
     }
 
     #[derive(StructOpt)]


### PR DESCRIPTION
Fixes #324 

This makes `version` even more special. normally, I would just relocated `lop_level_args()` after the `augment_clap` call, but this would break other use cases, like `clap::ArgGroup`, which must be set before the `.args()` are set. So, only the `.version()` call is relocated.

This PR also relaxes restriction on `#[structopt(name)]` - now it can take any expr, not only strung literal. The code is much cleaner this way.