### PR TITLE
Get rid of syn-full

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ structopt-derive = { path = "structopt-derive", version = "=0.4.0" }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-trybuild = "1.0.5"
+trybuild = { version = "1.0.5", features = ["diff"] }
 rustversion = "1"

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0/MIT"
 travis-ci = { repository = "TeXitoi/structopt" }
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
 quote = "1"
 proc-macro2 = "1"
 heck = "0.3.0"


### PR DESCRIPTION
We don't really need the "full" feature for syn, we don't even need some of the default features.

I also opted-in to "diff" for trybuild, quite useful feature.