### PR TITLE
Suppress all clippy lints except correctness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ matrix:
 
 script:
   - cargo test -- -D warnings
+
+jobs:
+  allow_failures:
+    - name: clippy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - rust: nightly
 
 script:
-  - cargo test -- -D warnings
+  - cargo test
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,15 @@ matrix:
         - markdown-link-check -c link-check-headers.json CHANGELOG.md
         - markdown-link-check -c link-check-headers.json examples/README.md
 
+    - rust: stable
+      name: clippy
+      before_script: rustup component add clippy
+      script: cargo clippy --all -- -D warnings
+
     - rust: 1.36.0
     - rust: stable
     - rust: beta
     - rust: nightly
 
 script:
-  - cargo test $FEATURES
+  - cargo test -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Upcoming]
+
+* `clippy` warnings triggered by generated code shall not annoy you anymore!
+  Except for those from `clippy::correctness`, these lints are useful even
+  for auto generated code.
+
 # v0.3.8 (2020-1-19)
 
 * You don't have to apply `#[no_version]` to every `enum` variant anymore.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,6 @@
 //! ```
 //! # extern crate clap;
 //! # fn parse_validator<T>(_: String) -> Result<(), String> { unimplemented!() }
-//! # fn main() {
 //! clap::Arg::with_name("speed")
 //!     .takes_value(true)
 //!     .multiple(false)
@@ -359,7 +358,6 @@
 //!     .long("velocity")
 //!     .help("Set speed")
 //!     .default_value("42");
-//! # }
 //! ```
 //!
 //! ## Specifying argument types
@@ -426,10 +424,8 @@
 //!
 //! }
 //!
-//! # fn main() {
 //! # Opt::from_clap(&Opt::clap().get_matches_from(
 //! #    &["test", "--foo-option", "", "-b", "", "--baz", "", "--custom", "", "positional"]));
-//! # }
 //! ```
 //!
 //! ## Default values
@@ -658,7 +654,6 @@
 //!   #[structopt(short, long, env = "PARAMETER_VALUE")]
 //!   parameter_value: String
 //! }
-//! # fn main() {}
 //! ```
 //!
 //! By default, values from the environment are shown in the help output (i.e. when invoking
@@ -781,7 +776,6 @@
 //!         all: bool
 //!     }
 //! }
-//! # fn main() {}
 //! ```
 //!
 //! Using `derive(StructOpt)` on an enum instead of a struct will produce
@@ -793,7 +787,6 @@
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! # fn main() {}
 //! #[derive(StructOpt)]
 //! struct MakeCookie {
 //!     #[structopt(name = "supervisor", default_value = "Puck", long = "supervisor")]
@@ -857,7 +850,6 @@
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! # fn main() {}
 //! #[derive(StructOpt)]
 //! struct Foo {
 //!     file: String,
@@ -934,7 +926,6 @@
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! # fn main() {}
 //! #[derive(StructOpt)]
 //! enum BaseCli {
 //!     Ghost10 {
@@ -965,7 +956,6 @@
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! # fn main() {}
 //! #[derive(StructOpt)]
 //! struct Cmdline {
 //!     /// switch on verbosity
@@ -1001,7 +991,6 @@
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! # fn main() {}
 //! use std::num::ParseIntError;
 //! use std::path::PathBuf;
 //!
@@ -1051,6 +1040,9 @@
 //! In the `try_from_*` variants, the function will run twice on valid input:
 //! once to validate, and once to parse. Hence, make sure the function is
 //! side-effect-free.
+
+// those mains are for a reason
+#![allow(clippy::needless_doctest_main)]
 
 #[doc(hidden)]
 pub use structopt_derive::*;

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -758,6 +758,7 @@ fn impl_structopt_for_struct(
             clippy::nursery,
             clippy::cargo
         )]
+        #[deny(clippy::correctness)]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOpt for #name {
             #clap_tokens
@@ -776,6 +777,7 @@ fn impl_structopt_for_struct(
             clippy::nursery,
             clippy::cargo
         )]
+        #[deny(clippy::correctness)]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOptInternal for #name {
             #augment_clap
@@ -813,6 +815,7 @@ fn impl_structopt_for_enum(
             clippy::nursery,
             clippy::cargo
         )]
+        #[deny(clippy::correctness)]
         impl ::structopt::StructOpt for #name {
             #clap_tokens
             #from_clap
@@ -830,6 +833,7 @@ fn impl_structopt_for_enum(
             clippy::nursery,
             clippy::cargo
         )]
+        #[deny(clippy::correctness)]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOptInternal for #name {
             #augment_clap

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -748,7 +748,16 @@ fn impl_structopt_for_struct(
     quote! {
         #[allow(unused_variables)]
         #[allow(unknown_lints)]
-        #[allow(clippy::all)]
+        #[allow(
+            clippy::style,
+            clippy::complexity,
+            clippy::pedantic,
+            clippy::restriction,
+            clippy::perf,
+            clippy::deprecated,
+            clippy::nursery,
+            clippy::cargo
+        )]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOpt for #name {
             #clap_tokens
@@ -757,7 +766,16 @@ fn impl_structopt_for_struct(
 
         #[allow(unused_variables)]
         #[allow(unknown_lints)]
-        #[allow(clippy::all)]
+        #[allow(
+            clippy::style,
+            clippy::complexity,
+            clippy::pedantic,
+            clippy::restriction,
+            clippy::perf,
+            clippy::deprecated,
+            clippy::nursery,
+            clippy::cargo
+        )]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOptInternal for #name {
             #augment_clap
@@ -785,7 +803,16 @@ fn impl_structopt_for_enum(
     quote! {
         #[allow(unknown_lints)]
         #[allow(unused_variables, dead_code, unreachable_code)]
-        #[allow(clippy::all)]
+        #[allow(
+            clippy::style,
+            clippy::complexity,
+            clippy::pedantic,
+            clippy::restriction,
+            clippy::perf,
+            clippy::deprecated,
+            clippy::nursery,
+            clippy::cargo
+        )]
         impl ::structopt::StructOpt for #name {
             #clap_tokens
             #from_clap
@@ -793,7 +820,16 @@ fn impl_structopt_for_enum(
 
         #[allow(unused_variables)]
         #[allow(unknown_lints)]
-        #[allow(clippy::all)]
+        #[allow(
+            clippy::style,
+            clippy::complexity,
+            clippy::pedantic,
+            clippy::restriction,
+            clippy::perf,
+            clippy::deprecated,
+            clippy::nursery,
+            clippy::cargo
+        )]
         #[allow(dead_code, unreachable_code)]
         impl ::structopt::StructOptInternal for #name {
             #augment_clap


### PR DESCRIPTION
The correctness category is for code that's outright wrong. I think we should not generate such code and the extra check won't hurt.