### PR TITLE
Support for hidden subcommands

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -89,6 +89,7 @@ pub struct Attrs {
     verbatim_doc_comment: Option<Ident>,
     has_custom_parser: bool,
     kind: Sp<Kind>,
+    hidden: bool,
 }
 
 impl Method {
@@ -245,6 +246,7 @@ impl Attrs {
 
             has_custom_parser: false,
             kind: Sp::new(Kind::Arg(Sp::new(Ty::Other, default_span)), default_span),
+            hidden: false,
         }
     }
 
@@ -275,6 +277,10 @@ impl Attrs {
                     let ty = Sp::call_site(Ty::Other);
                     let kind = Sp::new(Kind::Subcommand(ty), ident.span());
                     self.set_kind(kind);
+                }
+
+                Hidden(_) => {
+                    self.hidden = true;
                 }
 
                 ExternalSubcommand(ident) => {
@@ -637,6 +643,10 @@ impl Attrs {
                     || m.name == "about"
                     || m.name == "long_about"
             })
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        self.hidden
     }
 }
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -517,6 +517,11 @@ fn gen_augment_clap_enum(
                     }
                     Unnamed(..) => abort!(variant.span(), "non single-typed tuple enums are not supported"),
                 };
+                let hidden = if attrs.is_hidden() {
+                    quote!( #app_var.setting(::structopt::clap::AppSettings::Hidden) )
+                } else {
+                    quote!( #app_var )
+                };
 
                 let name = attrs.cased_name();
                 let from_attrs = attrs.top_level_methods();
@@ -525,6 +530,7 @@ fn gen_augment_clap_enum(
                     let app = app.subcommand({
                         let #app_var = ::structopt::clap::SubCommand::with_name(#name);
                         let #app_var = #arg_block;
+                        let #app_var = #hidden;
                         #app_var#from_attrs#version
                     });
                 }

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -20,6 +20,7 @@ pub enum StructOptAttr {
     ExternalSubcommand(Ident),
     NoVersion(Ident),
     VerbatimDocComment(Ident),
+    Hidden(Ident),
 
     // ident [= "string literal"]
     About(Ident, Option<LitStr>),
@@ -173,6 +174,7 @@ impl Parse for StructOptAttr {
                 "external_subcommand" => Ok(ExternalSubcommand(name)),
                 "no_version" => Ok(NoVersion(name)),
                 "verbatim_doc_comment" => Ok(VerbatimDocComment(name)),
+                "hidden" => Ok(Hidden(name)),
 
                 "default_value" => Ok(DefaultValue(name, None)),
                 "about" => (Ok(About(name, None))),


### PR DESCRIPTION
Adds support for a `#[structopt(hidden)]` attribute which hides subcommands (they don't show up in help) when present on an enum variant.

Currently it is possible to use this attribute anywhere, but it shouldn't do anything except when attached to an enum variant.

Was hoping to get some feedback and if this is something that can be merged I can fix up anything that needs fixing.