### PR TITLE
`clone-impls` missing from syn usage in structopt_derive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - rust: nightly
 
 script:
-  - cargo build
+  - cd structopt-derive && cargo build && cd ..
   - cargo test
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
     - rust: nightly
 
 script:
+  - cargo build
   - cargo test
 
 jobs:

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0/MIT"
 travis-ci = { repository = "TeXitoi/structopt" }
 
 [dependencies]
-syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
+syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro", "clone-impls"] }
 quote = "1"
 proc-macro2 = "1"
 heck = "0.3.0"


### PR DESCRIPTION
While messing around with trying to fix something else, I managed to run into a series of issues in `structopt_derive` of the form

```rust
error[E0277]: the trait bound `syn::expr::Expr: std::clone::Clone` is not satisfied
  --> src/attrs.rs:28:10
   |
28 |     Skip(Option<Expr>),
   |          ^^^^^^^^^^^^
   |          |
   |          expected an implementor of trait `std::clone::Clone`
   |          help: consider borrowing here: `&Option<Expr>`
   |
   = note: required because of the requirements on the impl of `std::clone::Clone` for `std::option::Option<syn::expr::Expr>`
   = note: required by `std::clone::Clone::clone
```

This PR adds a explicit build step of `structopt_derive` on it's own to demostrate the bug (see also https://travis-ci.org/TeXitoi/structopt/builds/656783840) and then adds the `clone-impls` feature to the `syn` features in `structopt-derive` to fix this. I think the build was working before because something else in `structopt` included syn and included the relevant feature, but `structopt_derive` didn't explicitly add it itself.
