### PR TITLE
Allow everything that implements ToString as default_value and env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [Upcoming]
+
+* Now everything that implements `ToString` can be passed to `#[structopt(default_value/env)]`.
+
+  ```rust
+  #[derive(StructOpt, PartialEq, Debug)]
+  struct Opt {
+      #[structopt(default_value = 2 + 2 * 2)]
+      arg: i32,
+  }
+  assert_eq!(Opt { arg: 6 }, Opt::from_iter(&["test"]));
+  assert_eq!(Opt { arg: 1 }, Opt::from_iter(&["test", "1"]));
+  ```
+
 # v0.3.14 (2020-04-22)
 
 * Minor documentation improvements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,7 @@
 //!     // The value doesn't have to be an `&str`,
 //!     // everything that implements ToString will do!
 //!     #[structopt(default_value = 2 + 2 * 2, long)]
-//!     prefix: String,
+//!     suffix: String,
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,10 @@
 //!
 //!     Usable only on field-level.
 //!
+//! - [`env`](#environment-variable-fallback): `default_value [= "environment variable"]`
+//!
+//!     Usable only on field-level.
+//!
 //! - [`rename_all`](#specifying-argument-types):
 //!     [`rename_all = "kebab"/"snake"/"screaming-snake"/"camel"/"pascal"/"verbatim"]`
 //!
@@ -450,7 +454,12 @@
 //! #[derive(StructOpt)]
 //! struct Opt {
 //!     #[structopt(default_value = "", long)]
-//!     prefix: String
+//!     prefix: String,
+//!
+//!     // The value doesn't have to be an `&str`,
+//!     // everything that implements ToString will do!
+//!     #[structopt(default_value = 2 + 2 * 2, long)]
+//!     prefix: String,
 //! }
 //! ```
 //!
@@ -664,7 +673,11 @@
 //! #[derive(StructOpt)]
 //! struct Foo {
 //!   #[structopt(short, long, env = "PARAMETER_VALUE")]
-//!   parameter_value: String
+//!   parameter_value: String,
+//!
+//!   // everything that implements ToString can be used as env
+//!   #[structopt(short, long, env = format!("SECOND_{}", "VALUE"))]
+//!   parameter_value2: u32,
 //! }
 //! ```
 //!
@@ -676,6 +689,7 @@
 //! ...
 //! OPTIONS:
 //!   -p, --parameter-value <parameter-value>     [env: PARAMETER_VALUE=env_value]
+//!   -p, --parameter-value2 <parameter-value2>   [env: SECOND_VALUE=env_value]
 //! ```
 //!
 //! In some cases this may be undesirable, for example when being used for passing

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -97,14 +97,12 @@ impl Parse for StructOptAttr {
                 }
             } else {
                 match input.parse::<Expr>() {
-                    Ok(expr) => {
-                        match &*name_str {
-                            "skip" => Ok(Skip(name, Some(expr))),
-                            "default_value" => Ok(DefaultValue(name, Some(expr))),
-                            "env" => Ok(Env(name, Some(expr))),
-                            _ => Ok(NameExpr(name, expr)),
-                        }
-                    }
+                    Ok(expr) => match &*name_str {
+                        "skip" => Ok(Skip(name, Some(expr))),
+                        "default_value" => Ok(DefaultValue(name, Some(expr))),
+                        "env" => Ok(Env(name, Some(expr))),
+                        _ => Ok(NameExpr(name, expr)),
+                    },
 
                     Err(_) => abort! {
                         assign_token,

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -13,7 +13,6 @@ pub enum StructOptAttr {
     // single-identifier attributes
     Short(Ident),
     Long(Ident),
-    Env(Ident),
     Flatten(Ident),
     Subcommand(Ident),
     ExternalSubcommand(Ident),
@@ -36,6 +35,7 @@ pub enum StructOptAttr {
     // ident [= arbitrary_expr]
     Skip(Ident, Option<Expr>),
     DefaultValue(Ident, Option<Expr>),
+    Env(Ident, Option<Expr>),
 
     // ident = arbitrary_expr
     NameExpr(Ident, Expr),
@@ -91,6 +91,7 @@ impl Parse for StructOptAttr {
 
                     "skip" => Ok(Skip(name, Some(lit_str_expr(lit)))),
                     "default_value" => Ok(DefaultValue(name, Some(lit_str_expr(lit)))),
+                    "env" => Ok(Env(name, Some(lit_str_expr(lit)))),
 
                     _ => Ok(NameLitStr(name, lit)),
                 }
@@ -100,6 +101,7 @@ impl Parse for StructOptAttr {
                         match &*name_str {
                             "skip" => Ok(Skip(name, Some(expr))),
                             "default_value" => Ok(DefaultValue(name, Some(expr))),
+                            "env" => Ok(Env(name, Some(expr))),
                             _ => Ok(NameExpr(name, expr)),
                         }
                     }
@@ -159,7 +161,6 @@ impl Parse for StructOptAttr {
             match name_str.as_ref() {
                 "long" => Ok(Long(name)),
                 "short" => Ok(Short(name)),
-                "env" => Ok(Env(name)),
                 "flatten" => Ok(Flatten(name)),
                 "subcommand" => Ok(Subcommand(name)),
                 "external_subcommand" => Ok(ExternalSubcommand(name)),
@@ -169,6 +170,7 @@ impl Parse for StructOptAttr {
                 "default_value" => Ok(DefaultValue(name, None)),
                 "about" => (Ok(About(name, None))),
                 "author" => (Ok(Author(name, None))),
+                "env" => Ok(Env(name, None)),
 
                 "skip" => Ok(Skip(name, None)),
 

--- a/tests/default_value.rs
+++ b/tests/default_value.rs
@@ -17,3 +17,17 @@ fn auto_default_value() {
     let help = get_long_help::<Opt>();
     assert!(help.contains("[default: 0]"));
 }
+
+#[test]
+fn default_value_to_string() {
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(default_value = 2 + 2 * 2)]
+        arg: i32,
+    }
+    assert_eq!(Opt { arg: 6 }, Opt::from_iter(&["test"]));
+    assert_eq!(Opt { arg: 1 }, Opt::from_iter(&["test", "1"]));
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("[default: 6]"));
+}

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,0 +1,20 @@
+mod utils;
+
+use structopt::StructOpt;
+use utils::*;
+
+#[test]
+fn env_to_string() {
+    std::env::set_var("ENV_VAR_1", "2");
+
+    #[derive(StructOpt, PartialEq, Debug)]
+    struct Opt {
+        #[structopt(env = format!("{}_{}_{}", "ENV", "VAR", 1))]
+        arg: i32,
+    }
+    assert_eq!(Opt { arg: 2 }, Opt::from_iter(&["test"]));
+    assert_eq!(Opt { arg: 1 }, Opt::from_iter(&["test", "1"]));
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("[env: ENV_VAR_1=2]"));
+}

--- a/tests/ui/no_to_string.rs
+++ b/tests/ui/no_to_string.rs
@@ -1,0 +1,12 @@
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct Opt {
+    #[structopt(short, default_value = ())]
+    b: String,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
+}

--- a/tests/ui/no_to_string.rs
+++ b/tests/ui/no_to_string.rs
@@ -4,6 +4,9 @@ use structopt::StructOpt;
 struct Opt {
     #[structopt(short, default_value = ())]
     b: String,
+
+    #[structopt(short, env = ())]
+    a: String,
 }
 
 fn main() {

--- a/tests/ui/no_to_string.stderr
+++ b/tests/ui/no_to_string.stderr
@@ -8,3 +8,14 @@ error[E0277]: `()` doesn't implement `std::fmt::Display`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
   = note: required because of the requirements on the impl of `std::string::ToString` for `()`
   = note: required by `std::string::ToString::to_string`
+
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+ --> $DIR/no_to_string.rs:8:30
+  |
+8 |     #[structopt(short, env = ())]
+  |                              ^^ `()` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `()`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required because of the requirements on the impl of `std::string::ToString` for `()`
+  = note: required by `std::string::ToString::to_string`

--- a/tests/ui/no_to_string.stderr
+++ b/tests/ui/no_to_string.stderr
@@ -1,0 +1,10 @@
+error[E0277]: `()` doesn't implement `std::fmt::Display`
+ --> $DIR/no_to_string.rs:5:40
+  |
+5 |     #[structopt(short, default_value = ())]
+  |                                        ^^ `()` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `()`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: required because of the requirements on the impl of `std::string::ToString` for `()`
+  = note: required by `std::string::ToString::to_string`

--- a/tests/ui/tuple_struct.stderr
+++ b/tests/ui/tuple_struct.stderr
@@ -3,3 +3,5 @@ error: structopt only supports non-tuple structs and enums
    |
 11 | #[derive(StructOpt, Debug)]
    |          ^^^^^^^^^
+   |
+   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Implemented handling of `default_value` and `env`. Maybe we could do the other methods too, but we were ever asked only about these two.