### PR TITLE
init external_doc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ debug = ["clap/debug"]
 no_cargo = ["clap/no_cargo"]
 doc = ["clap/doc"]
 paw = ["structopt-derive/paw"]
+external_doc = ["structopt-derive/external_doc"]
 
 [badges]
 travis-ci = { repository = "TeXitoi/structopt" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = ["clap/debug"]
 no_cargo = ["clap/no_cargo"]
 doc = ["clap/doc"]
 paw = ["structopt-derive/paw"]
-external_doc = ["structopt-derive/external_doc"]
+unstable_external_doc = ["structopt-derive/unstable_external_doc"]
 
 [badges]
 travis-ci = { repository = "TeXitoi/structopt" }

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -22,6 +22,7 @@ proc-macro-error = "1.0.0"
 
 [features]
 paw = []
+external_doc = []
 
 [lib]
 proc-macro = true

--- a/structopt-derive/Cargo.toml
+++ b/structopt-derive/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro-error = "1.0.0"
 
 [features]
 paw = []
-external_doc = []
+unstable_external_doc = []
 
 [lib]
 proc-macro = true

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -390,19 +390,19 @@ impl Attrs {
                         })
                         .filter(|nv| nv.path.is_ident("include"))
                         .filter_map(|nv| {
-                            if let Str(s) = &nv.lit {
-                                Some((s, nv.lit.span()))
+                            if let Str(s) = nv.lit {
+                                Some(s)
                             } else {
                                 None
                             }
                         })
-                        .map(|(s, span)| {
-                            let path = std::path::PathBuf::from("src").join(s.value());
+                        .map(|file_path| {
+                            let path = std::path::PathBuf::from("src").join(file_path.value());
                             let path = match path.canonicalize() {
                                 Ok(path) => path,
                                 Err(e) => abort!(
-                                    span,
-                                    "failed to canonicalize {:?} path. Error {}",
+                                    file_path,
+                                    "failed to canonicalize {:?} path: {}",
                                     &path,
                                     e
                                 ),
@@ -410,7 +410,7 @@ impl Attrs {
                             match std::fs::read_to_string(&path) {
                                 Ok(content) => content,
                                 Err(e) => {
-                                    abort!(span, "failed to read {:?} file. Error {}", &path, e)
+                                    abort!(file_path, "failed to read {:?} file: {}", &path, e)
                                 }
                             }
                         })

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -389,13 +389,7 @@ impl Attrs {
                             }
                         })
                         .filter(|nv| nv.path.is_ident("include"))
-                        .filter_map(|nv| {
-                            if let Str(s) = nv.lit {
-                                Some(s)
-                            } else {
-                                None
-                            }
-                        })
+                        .filter_map(|nv| if let Str(s) = &nv.lit { Some(s) } else { None })
                         .map(|file_path| {
                             let path = std::path::PathBuf::from("src").join(file_path.value());
                             let path = match path.canonicalize() {

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -11,7 +11,6 @@
 //! for the usage of `#[derive(StructOpt)]`.
 
 #![allow(clippy::large_enum_variant)]
-#![cfg_attr(feature = "unstable_external_doc", feature(external_doc))]
 
 extern crate proc_macro;
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -11,7 +11,7 @@
 //! for the usage of `#[derive(StructOpt)]`.
 
 #![allow(clippy::large_enum_variant)]
-#![cfg_attr(feature = "external_doc", feature(external_doc))]
+#![cfg_attr(feature = "unstable_external_doc", feature(external_doc))]
 
 extern crate proc_macro;
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -11,6 +11,7 @@
 //! for the usage of `#[derive(StructOpt)]`.
 
 #![allow(clippy::large_enum_variant)]
+#![cfg_attr(feature = "external_doc", feature(external_doc))]
 
 extern crate proc_macro;
 


### PR DESCRIPTION
Initial implementation for https://github.com/TeXitoi/structopt/issues/405

Adds a library-gated feature, which forwards it to the derive library, which declares usage of the unstable feature and then implements it on `structopt-derive/src/attrs.rs`.

This currently doesn't adds anything to the tests nor documentation..  
In the short run, personally I plan on using this PR as a patch for structopt.