### PR TITLE
Fix typo in required_if usage in crate docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,10 @@ How to completely remove version.
 
 How `#[structopt(rename_all)]` works.
 
+### [Required If](required_if.rs)
+
+How to use `#[structopt(required_if)]`.
+
 ### [Skip](skip.rs)
 
 How to use `#[structopt(skip)]`.

--- a/examples/required_if.rs
+++ b/examples/required_if.rs
@@ -1,0 +1,43 @@
+//! How to use `required_if` with structopt.
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt, PartialEq)]
+struct Opt {
+    /// Where to write the output: to `stdout` or `file`
+    #[structopt(short)]
+    out_type: String,
+
+    /// File name: only required when `out-type` is set to `file`
+    #[structopt(name = "FILE", required_if("out-type", "file"))]
+    file_name: Option<String>,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("{:?}", opt);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_opt_out_type_file_without_file_name_returns_err() {
+        let opt = Opt::from_iter_safe(&["test", "-o", "file"]);
+        let err = opt.unwrap_err();
+        assert_eq!(err.kind, clap::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn test_opt_out_type_file_with_file_name_returns_ok() {
+        let opt = Opt::from_iter_safe(&["test", "-o", "file", "filename"]);
+        let opt = opt.unwrap();
+        assert_eq!(
+            opt,
+            Opt {
+                out_type: "file".into(),
+                file_name: Some("filename".into()),
+            }
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@
 //!     #[structopt(short)]
 //!     out_type: String,
 //!
-//!     /// File name: only required when `out` is set to `file`
-//!     #[structopt(name = "FILE", required_if("out_type", "file"))]
+//!     /// File name: only required when `out-type` is set to `file`
+//!     #[structopt(name = "FILE", required_if("out-type", "file"))]
 //!     file_name: Option<String>,
 //! }
 //!


### PR DESCRIPTION
The `required_if` example in `lib.rs` doesn't actually require `file_name` when `out_type=file` because the arg name is wrong: clap uses hyphens for word separators, not underscores. This change fixes the example to use `out-type`. I decided against adding an inline test to keep the crate docs succinct.

I also added a separate `required_if` example with tests to validate this behavior. I separated this change into a separate commit in case you just want the typo fix without the new example.

Thank you for structopt!