### PR TITLE
Add support for lower/upper in rename_all

### DIFF
--- a/examples/rename_all.rs
+++ b/examples/rename_all.rs
@@ -17,6 +17,10 @@
 //! - **Snake Case**: Keep all letters lowercase and indicate word boundaries
 //!                   with underscores.
 //! - **Verbatim**: Use the original attribute name defined in the code.
+//!
+//! - **Lower Case**: Keep all letters lowercase and remove word boundaries.
+//!
+//! - **Upper Case**: Keep all letters upperrcase and remove word boundaries.
 
 use structopt::StructOpt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@
 //!     Usable only on field-level.
 //!
 //! - [`rename_all`](#specifying-argument-types):
-//!     [`rename_all = "kebab"/"snake"/"screaming-snake"/"camel"/"pascal"/"verbatim"]`
+//!     [`rename_all = "kebab"/"snake"/"screaming-snake"/"camel"/"pascal"/"verbatim"/"lower"/"upper"]`
 //!
 //!     Usable both on top level and field level.
 //!
@@ -309,7 +309,7 @@
 //!     Usable only on field-level.
 //!
 //! - [`rename_all_env`](##auto-deriving-environment-variables):
-//!     [`rename_all_env = "kebab"/"snake"/"screaming-snake"/"camel"/"pascal"/"verbatim"]`
+//!     [`rename_all_env = "kebab"/"snake"/"screaming-snake"/"camel"/"pascal"/"verbatim"/"lower"/"upper"]`
 //!
 //!     Usable both on top level and field level.
 //!

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -65,6 +65,10 @@ pub enum CasingStyle {
     Snake,
     /// Use the original attribute name defined in the code.
     Verbatim,
+    /// Keep all letters lowercase and remove word boundaries.
+    Lower,
+    /// Keep all letters uppercase and remove word boundaries.
+    Upper,
 }
 
 #[derive(Clone)]
@@ -188,6 +192,8 @@ impl CasingStyle {
             "screamingsnake" | "screamingsnakecase" => cs(ScreamingSnake),
             "snake" | "snakecase" => cs(Snake),
             "verbatim" | "verbatimcase" => cs(Verbatim),
+            "lower" | "lowercase" => cs(Lower),
+            "upper" | "uppercase" => cs(Upper),
             s => abort!(name, "unsupported casing: `{}`", s),
         }
     }
@@ -208,6 +214,8 @@ impl Name {
                     ScreamingSnake => s.to_shouty_snake_case(),
                     Snake => s.to_snake_case(),
                     Verbatim => s,
+                    Lower => s.to_lowercase().replace("_", ""),
+                    Upper => s.to_uppercase().replace("_", ""),
                 };
                 quote_spanned!(ident.span()=> #s)
             }

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -214,8 +214,8 @@ impl Name {
                     ScreamingSnake => s.to_shouty_snake_case(),
                     Snake => s.to_snake_case(),
                     Verbatim => s,
-                    Lower => s.to_lowercase().replace("_", ""),
-                    Upper => s.to_uppercase().replace("_", ""),
+                    Lower => s.to_snake_case().replace("_", ""),
+                    Upper => s.to_shouty_snake_case().replace("_", ""),
                 };
                 quote_spanned!(ident.span()=> #s)
             }

--- a/tests/argument_naming.rs
+++ b/tests/argument_naming.rs
@@ -309,3 +309,31 @@ fn test_rename_all_is_propagation_can_be_overridden() {
         Opt::from_clap(&Opt::clap().get_matches_from(&["test", "SECOND_VARIANT", "--foo-option"]))
     );
 }
+
+#[test]
+fn test_lower_is_renamed() {
+    #[derive(StructOpt, Debug, PartialEq)]
+    struct Opt {
+        #[structopt(rename_all = "lower", long)]
+        foo_option: bool,
+    }
+
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "--foooption"]))
+    );
+}
+
+#[test]
+fn test_upper_is_renamed() {
+    #[derive(StructOpt, Debug, PartialEq)]
+    struct Opt {
+        #[structopt(rename_all = "upper", long)]
+        foo_option: bool,
+    }
+
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::from_clap(&Opt::clap().get_matches_from(&["test", "--FOOOPTION"]))
+    );
+}


### PR DESCRIPTION
Some programs do not use anything to separate word boundaries.

For example a struct may contain the field `build_dir` while the flag is
`--builddir`.