### PR TITLE
Add support for renaming argument values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //!     - [External subcommands](#external-subcommands)
 //!     - [Flattening subcommands](#flattening-subcommands)
 //! - [Flattening](#flattening)
+//! - [Changing value names](#changing-value-names)
 //! - [Custom string parsers](#custom-string-parsers)
 //!
 //!
@@ -88,7 +89,7 @@
 //!     out_type: String,
 //!
 //!     /// File name: only required when `out-type` is set to `file`
-//!     #[structopt(name = "FILE", required_if("out-type", "file"))]
+//!     #[structopt(value_name = "FILE", required_if("out-type", "file"))]
 //!     file_name: Option<String>,
 //! }
 //!
@@ -295,6 +296,10 @@
 //! - [`flatten`](#flattening): `flatten`
 //!
 //!     Usable on field-level or single-typed tuple variants.
+//!
+//! - [`value_name`](#changing-value-names): `value_name = "value-name"`
+//!
+//!     Usable only on field-level.
 //!
 //! - [`subcommand`](#subcommands): `subcommand`
 //!
@@ -994,6 +999,22 @@
 //! This feature also makes it possible to define a `StructOpt` struct in a
 //! library, parse the corresponding arguments in the main argument parser, and
 //! pass off this struct to a handler provided by that library.
+//!
+//! ## Changing value names
+//!
+//! Giving values explicit names can be a helpful hint to the user about the
+//! type of the value. You can define custom value names using the `value_name`
+//! attribute:
+//!
+//! ```
+//! # use structopt::StructOpt;
+//! #[derive(StructOpt)]
+//! struct Opt {
+//!     // This will show up as `--count <NUM>` in the `--help` output.
+//!     #[structopt(value_name = "NUM")]
+//!     count: usize,
+//! }
+//! ```
 //!
 //! ## Custom string parsers
 //!

--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -368,6 +368,8 @@ impl Attrs {
                     self.has_custom_parser = true;
                     self.parser = Parser::from_spec(ident, spec);
                 }
+
+                ValueName(ident, lit_str) => self.push_method(ident, lit_str),
             }
         }
     }

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -30,6 +30,7 @@ pub enum StructOptAttr {
     RenameAllEnv(Ident, LitStr),
     RenameAll(Ident, LitStr),
     NameLitStr(Ident, LitStr),
+    ValueName(Ident, LitStr),
 
     // parse(parser_kind [= parser_func])
     Parse(Ident, ParserSpec),
@@ -98,6 +99,8 @@ impl Parse for StructOptAttr {
                         let expr = Expr::Lit(expr);
                         Ok(Skip(name, Some(expr)))
                     }
+
+                    "value_name" => Ok(ValueName(name, lit)),
 
                     _ => Ok(NameLitStr(name, lit)),
                 }

--- a/tests/value_name.rs
+++ b/tests/value_name.rs
@@ -1,0 +1,51 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+mod utils;
+
+use structopt::StructOpt;
+use utils::*;
+
+#[test]
+fn test_multiple_identical_value_names() {
+    #[derive(StructOpt, Debug, PartialEq)]
+    struct Opt {
+        #[structopt(long, value_name = "NUM")]
+        num1: u32,
+        #[structopt(long, value_name = "NUM")]
+        num2: u32,
+    }
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("--num1 <NUM>"));
+    assert!(help.contains("--num2 <NUM>"));
+}
+
+#[test]
+fn test_name_and_value_names() {
+    #[derive(StructOpt, Debug, PartialEq)]
+    struct Opt {
+        #[structopt(long, name = "not_num", value_name = "NUM")]
+        num: u32,
+    }
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("--num <NUM>"));
+}
+
+#[test]
+fn test_only_name() {
+    #[derive(StructOpt, Debug, PartialEq)]
+    struct Opt {
+        #[structopt(long, name = "not_num")]
+        num: u32,
+    }
+
+    let help = get_long_help::<Opt>();
+    assert!(help.contains("--num <not_num>"));
+}


### PR DESCRIPTION
I just found out that the number of values one can rename with `name =
"XXX"` is limited to one, since it's the unique argument value name.

Looking at the code and documentation, I could not find any way to set
clap's `value_name`, so this commit adds a new `value_name` attribute
which allows setting the name for a specific attribute.