### PR TITLE
Friendlier example text in tutorial

### DIFF
--- a/examples/git.rs
+++ b/examples/git.rs
@@ -7,7 +7,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "git")]
-/// the stupid content tracker
+/// the well-known version control tool
 enum Opt {
     /// fetch branches from remote repository
     Fetch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,7 +764,7 @@
 //!
 //! # use std::path::PathBuf;
 //! #[derive(StructOpt)]
-//! #[structopt(about = "the stupid content tracker")]
+//! #[structopt(about = "the well-known version control tool")]
 //! enum Git {
 //!     Add {
 //!         #[structopt(short)]


### PR DESCRIPTION
As a new Rust user, i did not find the snark against Git to be helpful.  It's probably a friendly joke, but it doesn't (IMHO) translate well in text.

My suggestion is to simply change this to a more neutral text to not alienate less experienced Rustaceans like myself :smiley: 

Thank you for your great library :raised_hands: 