### PR TITLE
Show "debug" in version for unoptimized build

### DIFF
--- a/structopt-derive/src/attrs.rs
+++ b/structopt-derive/src/attrs.rs
@@ -602,9 +602,16 @@ impl Attrs {
             (None, Some(m)) => m.to_token_stream(),
 
             (None, None) => std::env::var("CARGO_PKG_VERSION")
-                .map(|version| quote!( .version(#version) ))
+                .map(|version| {
+                    let mut if_debug = version;
+                    if cfg!(debug_assertions) {
+                        // If the build is debug type, express it explicitly from the version of
+                        // the package.
+                        if_debug = format!("{}-debug", if_debug);
+                    }
+                    quote!( .version(#if_debug))
+                })
                 .unwrap_or_default(),
-
             _ => quote!(),
         }
     }


### PR DESCRIPTION
For an unoptimized build, i.e. no `--release` flag, the binary does not
have a user friendly way to know if it's a debug build once transported
from the target folder.

This PR adds a "-debug" string when the binary is built with
"debug_assertions".