### PR TITLE
add basic support for generic structs and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+* Add support for [generics in derive](https://github.com/TeXitoi/structopt/issues/128)
+
 # v0.3.21 (2020-11-30)
 
 * Fixed [another breakage](https://github.com/TeXitoi/structopt/issues/447)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,15 +1058,17 @@
 //! ## Generics
 //!
 //! Generic structs and enums can be used. They require explicit trait bounds
-//! any generic types that will be used by the `StructOpt` derive macro.
+//! on any generic types that will be used by the `StructOpt` derive macro. In
+//! some cases, associated types will require additional bounds. See the usage
+//! of `FromStr` below for an example of this.
 //!
 //! ```
 //! # use structopt::StructOpt;
-//! use std::str::FromStr;
+//! use std::{fmt, str::FromStr};
 //!
 //! // a struct with single custom argument
 //! #[derive(StructOpt)]
-//! struct GenericArgs<T:FromStr> {
+//! struct GenericArgs<T:FromStr> where <T as FromStr>::Err: fmt::Display + fmt::Debug {
 //!     generic_arg_1: String,
 //!     generic_arg_2: String,
 //!     custom_arg_1: T

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 //!     - [Flattening subcommands](#flattening-subcommands)
 //! - [Flattening](#flattening)
 //! - [Custom string parsers](#custom-string-parsers)
+//! - [Generics](#generics)
 //!
 //!
 //!
@@ -1053,6 +1054,40 @@
 //! In the `try_from_*` variants, the function will run twice on valid input:
 //! once to validate, and once to parse. Hence, make sure the function is
 //! side-effect-free.
+//!
+//! ## Generics
+//!
+//! Generic structs and enums can be used. They require explicit trait bounds
+//! any generic types that will be used by the `StructOpt` derive macro.
+//!
+//! ```
+//! # use structopt::StructOpt;
+//! use std::str::FromStr;
+//!
+//! // a struct with single custom argument
+//! #[derive(StructOpt)]
+//! struct GenericArgs<T:FromStr> {
+//!     generic_arg_1: String,
+//!     generic_arg_2: String,
+//!     custom_arg_1: T
+//! }
+//! ```
+//!
+//! or
+//!
+//! ```
+//! # use structopt::StructOpt;
+//! // a struct with multiple custom arguments in a substructure
+//! #[derive(StructOpt)]
+//! struct GenericArgs<T:StructOpt> {
+//!     generic_arg_1: String,
+//!     generic_arg_2: String,
+//!     #[structopt(flatten)]
+//!     custom_args: T
+//! }
+//! ```
+
+
 
 // those mains are for a reason
 #![allow(clippy::needless_doctest_main)]

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -816,9 +816,6 @@ fn split_structopt_generics_for_impl(generics: &Generics) -> (ImplGenerics, Type
             if type_param_bounds_contains(&param.bounds, "StructOpt") {
                 trait_bound_amendments.add(quote!{ #param_ident : ::structopt::StructOptInternal });
             }
-            if type_param_bounds_contains(&param.bounds, "FromStr") {
-                trait_bound_amendments.add(quote!{ < #param_ident as ::std::str::FromStr>::Err : ::std::fmt::Display + ::std::fmt::Debug });
-            }
         }
     }
 
@@ -828,9 +825,6 @@ fn split_structopt_generics_for_impl(generics: &Generics) -> (ImplGenerics, Type
                 let predicate_bounded_ty = &predicate.bounded_ty;
                 if type_param_bounds_contains(&predicate.bounds, "StructOpt") {
                     trait_bound_amendments.add(quote!{ #predicate_bounded_ty : ::structopt::StructOptInternal });
-                }
-                if type_param_bounds_contains(&predicate.bounds, "FromStr") {
-                    trait_bound_amendments.add(quote!{ < #predicate_bounded_ty as ::std::str::FromStr>::Err : ::std::fmt::Display + ::std::fmt::Debug });
                 }
             }
         }

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -559,10 +559,10 @@ fn gen_augment_clap_enum(
     }
 }
 
-fn gen_from_clap_enum(name: &Ident) -> TokenStream {
+fn gen_from_clap_enum() -> TokenStream {
     quote! {
         fn from_clap(matches: &::structopt::clap::ArgMatches) -> Self {
-            <#name as ::structopt::StructOptInternal>::from_subcommand(matches.subcommand())
+            <Self as ::structopt::StructOptInternal>::from_subcommand(matches.subcommand())
                 .expect("structopt misuse: You likely tried to #[flatten] a struct \
                          that contains #[subcommand]. This is forbidden.")
         }
@@ -816,7 +816,7 @@ fn impl_structopt_for_enum(
     let attrs = basic_clap_app_gen.attrs;
 
     let augment_clap = gen_augment_clap_enum(variants, &attrs);
-    let from_clap = gen_from_clap_enum(name);
+    let from_clap = gen_from_clap_enum();
     let from_subcommand = gen_from_subcommand(name, variants, &attrs);
     let paw_impl = gen_paw_impl(name);
 

--- a/structopt-derive/src/lib.rs
+++ b/structopt-derive/src/lib.rs
@@ -755,14 +755,14 @@ fn gen_paw_impl(_: &ImplGenerics, _: &Ident, _: &TypeGenerics, _: &TokenStream) 
 fn split_structopt_generics_for_impl(generics: &Generics) -> (ImplGenerics, TypeGenerics, TokenStream) {
     use syn::{ token::Add, TypeParamBound::Trait };
 
-    fn path_is_structop(path: &Path) -> bool {
+    fn path_is_structopt(path: &Path) -> bool {
         path.segments.last().unwrap().ident == "StructOpt"
     }
 
-    fn type_param_bounds_contains_structop(bounds: &Punctuated<TypeParamBound, Add>) -> bool {
+    fn type_param_bounds_contains_structopt(bounds: &Punctuated<TypeParamBound, Add>) -> bool {
         for bound in bounds {
             if let Trait(bound) = bound {
-                if path_is_structop(&bound.path) {
+                if path_is_structopt(&bound.path) {
                     return true;
                 }
             }
@@ -775,7 +775,7 @@ fn split_structopt_generics_for_impl(generics: &Generics) -> (ImplGenerics, Type
     for param in &generics.params {
         if let GenericParam::Type(param) = param {
             let param_ident = &param.ident;
-            if type_param_bounds_contains_structop(&param.bounds) {
+            if type_param_bounds_contains_structopt(&param.bounds) {
                 if !trait_bound_amendments.is_empty() {
                     trait_bound_amendments.extend(quote!{ , });
                 }
@@ -788,7 +788,7 @@ fn split_structopt_generics_for_impl(generics: &Generics) -> (ImplGenerics, Type
         for predicate in &where_clause.predicates {
             if let WherePredicate::Type(predicate) = predicate {
                 let predicate_bounded_ty = &predicate.bounded_ty;
-                if type_param_bounds_contains_structop(&predicate.bounds) {
+                if type_param_bounds_contains_structopt(&predicate.bounds) {
                     if !trait_bound_amendments.is_empty() {
                         trait_bound_amendments.extend(quote!{ , });
                     }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,0 +1,86 @@
+
+use structopt::StructOpt;
+
+#[test]
+fn generic_struct_flatten() {
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Inner{
+        pub answer: isize
+    }
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Outer<T:StructOpt>{
+        #[structopt(flatten)]
+        pub inner: T
+    }
+
+    assert_eq!(
+        Outer{inner: Inner{ answer: 42 }},
+        Outer::from_iter(&[ "--answer",  "42" ])
+    )
+}
+
+#[test]
+fn generic_struct_flatten_w_where_clause() {
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Inner{
+        pub answer: isize
+    }
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Outer<T> where T:StructOpt {
+        #[structopt(flatten)]
+        pub inner: T
+    }
+
+    assert_eq!(
+        Outer{inner: Inner{ answer: 42 }},
+        Outer::from_iter(&[ "--answer",  "42" ])
+    )
+}
+
+#[test]
+fn generic_enum() {
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Inner{
+        pub answer: isize
+    }
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    enum GenericEnum<T: StructOpt> {
+
+        Start(T),
+        Stop,
+    }
+
+    assert_eq!(
+        GenericEnum::Start(Inner{answer: 42}),
+        GenericEnum::from_iter(&[ "test", "start", "42" ])
+    )
+
+}
+
+#[test]
+fn generic_enum_w_where_clause() {
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Inner{
+        pub answer: isize
+    }
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    enum GenericEnum<T> where T: StructOpt {
+
+        Start(T),
+        Stop,
+    }
+
+    assert_eq!(
+        GenericEnum::Start(Inner{answer: 42}),
+        GenericEnum::from_iter(&[ "test", "start", "42" ])
+    )
+
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -101,3 +101,21 @@ fn generic_w_fromstr_trait_bound() {
         Opt::<isize>::from_iter([& "--answer", "42" ])
     )
 }
+
+#[test]
+fn generic_wo_trait_bound() {
+
+    use std::time::Duration;
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Opt<T> {
+        answer: isize,
+        #[structopt(skip)]
+        took: Option<T>
+    }
+
+    assert_eq!(
+        Opt::<Duration>{answer:42,took:None},
+        Opt::<Duration>::from_iter([& "--answer", "42" ])
+    )
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -119,3 +119,19 @@ fn generic_wo_trait_bound() {
         Opt::<Duration>::from_iter([& "--answer", "42" ])
     )
 }
+
+#[test]
+fn generic_where_clause_w_trailing_comma() {
+
+    use std::str::FromStr;
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Opt<T> where T:FromStr, {
+        pub answer: T
+    }
+
+    assert_eq!(
+        Opt::<isize>{answer:42},
+        Opt::<isize>::from_iter(&[ "--answer", "42" ])
+    )
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -84,3 +84,20 @@ fn generic_enum_w_where_clause() {
     )
 
 }
+
+#[test]
+fn generic_w_fromstr_trait_bound() {
+
+    use std::str::FromStr;
+
+    #[derive(StructOpt,PartialEq,Debug)]
+    struct Opt<T> where T:FromStr
+    {
+        answer: T
+    }
+
+    assert_eq!(
+        Opt::<isize>{answer:42},
+        Opt::<isize>::from_iter([& "--answer", "42" ])
+    )
+}

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -88,10 +88,10 @@ fn generic_enum_w_where_clause() {
 #[test]
 fn generic_w_fromstr_trait_bound() {
 
-    use std::str::FromStr;
+    use std::{fmt, str::FromStr};
 
     #[derive(StructOpt,PartialEq,Debug)]
-    struct Opt<T> where T:FromStr
+    struct Opt<T> where T:FromStr, <T as FromStr>::Err: fmt::Debug + fmt::Display
     {
         answer: T
     }
@@ -123,10 +123,10 @@ fn generic_wo_trait_bound() {
 #[test]
 fn generic_where_clause_w_trailing_comma() {
 
-    use std::str::FromStr;
+    use std::{fmt, str::FromStr};
 
     #[derive(StructOpt,PartialEq,Debug)]
-    struct Opt<T> where T:FromStr, {
+    struct Opt<T> where T:FromStr, <T as FromStr>::Err: fmt::Debug + fmt::Display {
         pub answer: T
     }
 


### PR DESCRIPTION
This PR provides (at least basic) support for generics when deriving `StructOpt` (issue #128). It's probably not the ideal final implementation, but from what I can see, it improves the situation and makes some use cases possible.