### PR TITLE
Bump strum dev-dependency to latest version (0.20 -> 0.21)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ paw_dep = { version = "1", optional = true, package = "paw" }
 [dev-dependencies]
 trybuild = { version = "1.0.5", features = ["diff"] }
 rustversion = "1"
-strum = { version = "0.20", features = ["derive"] }
+strum = { version = "0.21", features = ["derive"] }


### PR DESCRIPTION
This requires no code changes, the example still compiles fine.

strum 0.21 claims to have an MSRV of 1.32.0, and structopt's MSRV is 1.36.0, so that should not be a problem either.