### PR TITLE
Fix duplication of aliases in subcommands

### DIFF
--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -117,6 +117,34 @@ fn issue_359() {
 }
 
 #[test]
+fn issue_418() {
+    use structopt::StructOpt;
+
+    #[derive(Debug, StructOpt)]
+    struct Opts {
+        #[structopt(subcommand)]
+        /// The command to run
+        command: Command,
+    }
+
+    #[derive(Debug, StructOpt)]
+    enum Command {
+        /// Reticulate the splines
+        #[structopt(visible_alias = "ret")]
+        Reticulate {
+            /// How many splines
+            num_splines: u8,
+        },
+        /// Frobnicate the rest
+        #[structopt(visible_alias = "frob")]
+        Frobnicate,
+    }
+
+    let help = get_long_help::<Opts>();
+    assert!(help.contains("Reticulate the splines [aliases: ret]"));
+}
+
+#[test]
 fn issue_490() {
     use std::iter::FromIterator;
     use std::str::FromStr;


### PR DESCRIPTION
This PR fixes the issue where all top level methods were duplicated for subcommands with fields (see issue #418). For some attributes, such as aliases, this resulted in duplicate output.

The issue was caused by the fact that for named enum variants `gen_augmentation` was used to generate the clap data, which already parses the attributes, while later on `attrs.top_level_methods()` was used to parse attributes *again*, so that the attributes were parsed and generated twice. For some attributes, this merely resulted in the attribute being set twice, which is fairly harmless, but for some attributes, such as aliases, this resulted in the alias being added to the vector of aliases twice, which in turn causes the alias to be printed twice in the help message.

Fixes #418 