### PR TITLE
Custom Structopt Crate Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.3.26 (2021-10-19)
+
+* Added ability to specify custom structopt crate path [#506](https://github.com/TeXitoi/structopt/pull/506)
+
 # v0.3.25 (2021-10-18)
 
 * Fix duplication of aliases in subcommands [#504](https://github.com/TeXitoi/structopt/pull/504)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.3.26 (2021-10-19)
+# v0.3.25 (2021-10-19)
 
 * Added ability to specify custom structopt crate path [#506](https://github.com/TeXitoi/structopt/pull/506)
 

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -6,7 +6,7 @@ use syn::{
     self, parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
     punctuated::Punctuated,
-    Attribute, Expr, ExprLit, Ident, Lit, LitBool, LitStr, Token,
+    Attribute, Expr, ExprLit, Ident, Lit, LitBool, LitStr, Path, Token,
 };
 
 pub enum StructOptAttr {
@@ -42,6 +42,9 @@ pub enum StructOptAttr {
 
     // ident(arbitrary_expr,*)
     MethodCall(Ident, Vec<Expr>),
+
+    // ident = ::structopt::path
+    StructoptPath(Ident, Path),
 }
 
 impl Parse for StructOptAttr {
@@ -97,6 +100,11 @@ impl Parse for StructOptAttr {
                         };
                         let expr = Expr::Lit(expr);
                         Ok(Skip(name, Some(expr)))
+                    }
+
+                    "crate_path" => {
+                        let structopt_path = syn::parse_str::<Path>(&lit_str).unwrap();
+                        Ok(StructoptPath(name, structopt_path))
                     }
 
                     _ => Ok(NameLitStr(name, lit)),

--- a/structopt-derive/src/parse.rs
+++ b/structopt-derive/src/parse.rs
@@ -102,7 +102,7 @@ impl Parse for StructOptAttr {
                         Ok(Skip(name, Some(expr)))
                     }
 
-                    "crate_path" => {
+                    "structopt_path" => {
                         let structopt_path = syn::parse_str::<Path>(&lit_str).unwrap();
                         Ok(StructoptPath(name, structopt_path))
                     }


### PR DESCRIPTION
This PR provides the initial work around passing `structopt_path` to the procedural macro (https://github.com/TeXitoi/structopt/issues/339).

There's two places left that I'm having trouble seeing where I can pull the `structopt_path` attribute in:

https://github.com/TeXitoi/structopt/blob/da1fff81aded1c239ffcbd0a27ccdc7f28f74ff2/structopt-derive/src/lib.rs#L993-L1004

Not entirely sure how to handle this, I'm guessing the dummy returned by this block wouldn't be ideal for a user if it ended up getting used in a package built on top of structopt?


The other location is in attrs.rs:

https://github.com/TeXitoi/structopt/blob/da1fff81aded1c239ffcbd0a27ccdc7f28f74ff2/structopt-derive/src/attrs.rs#L322-L331

Additionally, I had tried using `crate` as serde does in their implementation but kept running into a compilation error: "expected identifier" (which I guess creates an issue because it's a keyword) so went with this naming.  Not sure what's best to name it if not `crate`,  so went with `structopt_path`.  It might be due to the way that serde is parsing the macro attributes but the way I've done it is consistent with the rest of the cases for parsing the arguments.  Happy to give it another go if you'd like this to be consistent with serde.

- [ ] Add unit tests
- [ ] Add documentation around extending structopt with the new functionality that explicitly mentions the “structopt_path” argument must come first in the arguments to the procedural macros.
- [ ] Try to get the one remaining case working based on the suggested solution.