### PR TITLE
Link to the clap method list in the documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,9 @@
 //! ## Raw methods
 //!
 //! They are the reason why `structopt` is so flexible. **Every and each method from
-//! `clap::App/Arg` can be used this way!**
+//! `clap::App/Arg` can be used this way!** See the [`clap::App`
+//! methods](https://docs.rs/clap/2/clap/struct.App.html) and [`clap::Arg`
+//! methods](https://docs.rs/clap/2/clap/struct.Arg.html).
 //!
 //! ```
 //! # #[derive(structopt::StructOpt)] struct S {


### PR DESCRIPTION
When I first started using structopt, I had also not used clap. It wasn't clear to me that clap contained a ton of functionality, and that the clap docs were the likely place to look if I needed to change some default behavior. The structopt docs are perfectly clear as is, but I think adding links will drive home the point that there are a ton of extra methods available (listed in the clap documentation).

Additionally, linking to the list of clap methods may be convenient for users browsing the structopt documentation who realize something they need doesn't exist in structopt.