### PR TITLE
Fix link to the migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As clap v3 is now out, and the structopt features are integrated into (almost as
 
 Bugs will be fixed, and documentation improvements will be accepted.
 
-See the [structopt -> clap migration guide](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrate-structopt)
+See the [structopt -> clap migration guide](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#migrating)
 
 ## Documentation
 


### PR DESCRIPTION
This just fixes a link in README.md 😄 