### PR TITLE
Add StructOpt::gen_help to generate help string

### DIFF
--- a/examples/gen_help.rs
+++ b/examples/gen_help.rs
@@ -1,0 +1,25 @@
+use structopt::StructOpt;
+
+/// A basic example
+#[derive(StructOpt, Debug)]
+#[structopt(name = "basic")]
+struct Opt {
+    /// Activate debug mode
+    #[structopt(short, long)]
+    _debug: bool,
+}
+
+fn main() {
+    // Running this example will print this message
+    // ----------------------------------------------------
+    // basic 0.3.26
+    // A basic example
+    //
+    // USAGE:
+    //     basic [FLAGS]
+    //
+    // FLAGS:
+    //     -d, --debug    Activate debug mode
+    // ----------------------------------------------------
+    println!("{}", <Opt as StructOpt>::gen_help().unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1189,6 +1189,24 @@ pub trait StructOpt {
     {
         Ok(Self::from_clap(&Self::clap().get_matches_from_safe(iter)?))
     }
+
+    /// Generate help string from the struct
+    ///
+    /// Returns the string which is the same as output with `--help` or a [`clap::Error`] if failure.
+    ///
+    /// **NOTE**: If help string with invalid utf8 error will map to [`clap::Error`] with [`clap::ErrorKind::InvalidUtf8`]
+    fn gen_help() -> Result<String, clap::Error> {
+        let mut help = Vec::<u8>::new();
+        let app = Self::clap();
+        app.write_help(&mut help)?;
+        Ok(std::str::from_utf8(&help.as_slice())
+            .map_err(|e| clap::Error {
+                message: "The output of `--help` is not utf8 encoding".into(),
+                kind: clap::ErrorKind::InvalidUtf8,
+                info: Some(vec![e.to_string()]),
+            })?
+            .to_string())
+    }
 }
 
 /// This trait is NOT API. **SUBJECT TO CHANGE WITHOUT NOTICE!**.


### PR DESCRIPTION
Hi there,
Thanks for providing this fantastic crate, I love it so much.

If there is a way to generate the help string from `struct` directly will be really helpful for me.

This method may be a good idea to do.
`<Opt as StructOpt>::gen_help()`

Such that I can avoid getting the help string by calling the program itself again like following
https://github.com/yanganto/s3rs/blob/master/src/command/mod.rs#L539-L547

If there is anything more I can do in this PR please kindly let me know.
Thank you for reviewing.